### PR TITLE
fix(Footer): logo plate refinements in columns variant

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -364,6 +364,17 @@ export const Footer = ({
                 © {currentYear} {tWithFallback('footer.copyright', 'Røde Kors')}
               </p>
             </div>
+
+            {/* Brand logo — bottom-left. If a logo src is supplied, render it
+                directly (the asset carries its own frame); otherwise fall back
+                to the inline Red Cross logo on a white plate. */}
+            {primaryLogoSrc ? (
+              <img src={primaryLogoSrc} alt={primaryLogoAlt} className={styles.dpLogoImg} />
+            ) : (
+              <div className={styles.dpLogoBox} data-color-scheme="light">
+                <RedCrossLogo />
+              </div>
+            )}
           </div>
         </div>
       </footer>

--- a/src/components/Footer/styles.module.css
+++ b/src/components/Footer/styles.module.css
@@ -689,6 +689,31 @@
   margin: 0;
 }
 
+/* Brand logo plate: left-aligned at the bottom; data-color-scheme="light"
+   makes the box white via tokens. */
+.dpLogoBox {
+  display: flex;
+  width: fit-content;
+  align-items: center;
+  justify-content: center;
+  margin-top: var(--ds-size-16, 64px);
+  padding: var(--ds-size-1, 4px) var(--ds-size-2, 8px);
+  background-color: var(--ds-color-neutral-background-default);
+  border-radius: var(--ds-border-radius-sm, 4px);
+}
+
+.dpLogoBox .redCrossLogo {
+  width: 150px;
+}
+
+/* Pre-framed logo asset (e.g. logo-frame.svg) — rendered as-is, no extra plate. */
+.dpLogoImg {
+  display: block;
+  width: 180px;
+  height: auto;
+  margin-top: var(--ds-size-16, 64px);
+}
+
 @media (max-width: 1024px) {
   .dpContainer {
     padding: var(--ds-size-12, 48px) var(--ds-size-8, 32px);


### PR DESCRIPTION
Follow-up footer fixes that **missed PR #10** — that PR was merged before these commits were pushed, so they never reached `main` (currently v1.2.3, where the `columns` footer has no logo).

## Changes (Footer `columns` variant only)
- **Restore the brand logo** at the bottom-left in a white plate (the earlier centred version was removed; this is the correct left-aligned placement).
- **Tighten the plate padding** to 4px vertical / 8px horizontal (was 16/32 — too much white).
- **Support a pre-framed logo via `primaryLogoSrc`**: when set, the asset is rendered directly (it carries its own frame) instead of the inline logo + white plate. Generic — any project can supply its own logo.

## Scope
Footer component only (`src/components/Footer/index.tsx`, `styles.module.css`). No docs-app files, no assets.

## Verification
- `tsc --noEmit` clean
- `npm run build` (library) succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)