### PR TITLE
chore(deps): bump rk-design-tokens to ^1.0.49

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@types/classnames": "^2.3.0",
         "classnames": "^2.5.1",
         "embla-carousel-react": "^8.6.0",
-        "rk-design-tokens": "^1.0.47"
+        "rk-design-tokens": "^1.0.49"
       },
       "devDependencies": {
         "@chromatic-com/storybook": "^4.1.2",
@@ -8406,9 +8406,9 @@
       }
     },
     "node_modules/rk-design-tokens": {
-      "version": "1.0.47",
-      "resolved": "https://registry.npmjs.org/rk-design-tokens/-/rk-design-tokens-1.0.47.tgz",
-      "integrity": "sha512-7PUFgXceLiD9zTkLuU+tYbCMoyT3NiyCRB99tAuwkHUimKvtoaznyq+Vok1zBX3UMuzPQ5aBBIkACD6mvv3wHA=="
+      "version": "1.0.49",
+      "resolved": "https://registry.npmjs.org/rk-design-tokens/-/rk-design-tokens-1.0.49.tgz",
+      "integrity": "sha512-rOuj+06pzOgx44rwnuO2zCO8FsureBSNY1u5K9zUJX1GcPv6zd8QiAAR85Pw2ZSiA2b1fAwnS8IN2rogmMK+3Q=="
     },
     "node_modules/rollup": {
       "version": "4.60.2",

--- a/package.json
+++ b/package.json
@@ -135,6 +135,6 @@
     "@types/classnames": "^2.3.0",
     "classnames": "^2.5.1",
     "embla-carousel-react": "^8.6.0",
-    "rk-design-tokens": "^1.0.47"
+    "rk-design-tokens": "^1.0.49"
   }
 }


### PR DESCRIPTION
## Summary

Pulls in the token release that completes the token-managed button styling from #14:

- `--ds-border-radius-base`: `0.25rem` → `624.9375rem` (full). `--ds-border-radius-default` maps to base, and Digdir's `.ds-button` consumes it — **buttons render as pills again, now purely via tokens**. The sm–xl radius steps stay clamped by the `min(…, scale)` math, so they are unaffected apart from `sm` (0.125rem → 0.25rem).
- Refreshed tinted surfaces (light + dark): ocean `background-tinted` → `#eaf7ff`, jungle `surface-tinted/hover` → `#e6f6e4`/`#cde4ca`, neutral `background-tinted` → `#f7f3ef`.

Note: `--ds-border-radius-default` is consumed by other Digdir components too, so the full radius applies design-wide wherever that token is used — intended per the token-managed styling direction.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm test` — 294 tests / 47 story files pass, including the a11y checks against the new tinted colors

🤖 Generated with [Claude Code](https://claude.com/claude-code)