### PR TITLE
chore(testing): comply with NRK testpolicy, teststrategi og testpraksis (GitHub-adapted)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,68 @@
+name: Feilrapport (bug)
+description: Rapporter en feil i designsystemet
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Takk for at du melder feilen! En god feilrapport gjør at vi kan reprodusere og rette raskere.
+        (Jf. «Testing – prinsipper og praksis» kap. 9.4 — tydelig tittel, faktisk og forventet resultat, steg og skjermbilder.)
+  - type: textarea
+    id: actual
+    attributes:
+      label: Hva skjedde? (faktisk resultat)
+      description: Beskriv feilen slik den oppstod.
+      placeholder: 'Eksempel: DatePicker lukker seg når jeg klikker på "neste måned".'
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Hva forventet du? (forventet resultat)
+      placeholder: 'Eksempel: Kalenderen skal bla til neste måned og forbli åpen.'
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steg for å reprodusere
+      description: Nummererte steg som utløser feilen.
+      placeholder: |
+        1. Gå til …
+        2. Klikk på …
+        3. Se feilen
+    validations:
+      required: true
+  - type: input
+    id: component
+    attributes:
+      label: Komponent/område
+      placeholder: 'Eksempel: DatePicker'
+    validations:
+      required: true
+  - type: dropdown
+    id: severity
+    attributes:
+      label: Alvorlighetsgrad
+      description: Jf. TESTING.md kap. 10.
+      options:
+        - Kritisk — ubrukelig, sikkerhets-/tilgjengelighetsbrudd eller produksjonsfeil
+        - Høy — vesentlig funksjonalitet feiler, workaround finnes
+        - Middels — feil med enkel workaround
+        - Lav — kosmetisk
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Versjon av rk-designsystem
+      placeholder: 'Eksempel: 1.2.5'
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Miljø og vedlegg
+      description: Nettleser/OS/rammeverk, skjermbilder eller video.
+      placeholder: 'Chrome 141 / macOS, Next.js 15. Skjermbilde vedlagt.'

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+<!-- Beskriv endringen: hva, hvorfor, og eventuelle designbeslutninger. -->
+
+## Endringer
+
+-
+
+## Testsjekkliste (jf. TESTING.md kap. 9)
+
+- [ ] Typecheck og lint er grønne lokalt
+- [ ] Endret/ny funksjonalitet har stories med `play`-assertions (enhetstest)
+- [ ] Full testsuite kjørt lokalt (`npm test`) — regresjon
+- [ ] Tilgjengelighet verifisert (a11y-addon feiler ikke)
+- [ ] Visuelt verifisert i Storybook (lys/mørk modus) — skjermbilde vedlagt ved visuelle endringer
+- [ ] Breaking changes er flagget i tittelen (`!`) og beskrevet under
+- [ ] AI-kontekstartefakter regenerert ved API-endringer (`npm run generate-metadata && npm run update-ai-guide-components && npm run generate-ai-context-manifest`)
+
+## Akseptert risiko / kjente begrensninger
+
+<!-- Hva er bevisst ikke testet, og hvorfor? Skriv «Ingen» hvis alt er dekket. -->
+
+Fixes #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,12 +1,59 @@
-name: Build and Deploy
+name: CI
 
+# Testpolicy: test tidlig og kontinuerlig, full regresjon på hver endring,
+# ingenting produksjonssettes utestet (se TESTING.md).
 on:
   push:
     branches:
       - main
+  pull_request:
 
 jobs:
-  build-and-deploy:
+  # Full kvalitetssjekk av innsendt kode — kjøres på hver PR og hver push.
+  # Dette er regresjonstesten: hele suiten, ikke bare det som er endret.
+  test:
+    name: Lint, typecheck, test & build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium
+
+      - name: Test (full regression, all stories + a11y)
+        run: npm test
+
+      - name: Build package
+        run: npm run build
+
+      - name: Build Storybook
+        run: npm run build-storybook
+
+      - name: Build Main Application
+        run: npm run build:app
+
+  # Deploy kjøres kun på push til main, og kun når testjobben er grønn.
+  # Token-oppdateringen testes FØR den committes og deployes.
+  deploy:
+    name: Update tokens, verify & deploy
+    if: github.event_name == 'push'
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
@@ -32,22 +79,16 @@ jobs:
       - name: Update design tokens package
         run: npm update rk-design-tokens
 
+      - name: Install Playwright browsers
+        run: npx playwright install chromium
+
+      - name: Test with updated tokens (regression before commit/deploy)
+        run: npm test
+
       - name: Commit and Push Dependency Updates
         uses: stefanzweifel/git-auto-commit-action@v5
         with:
           commit_message: "chore(deps): update rk-design-tokens to latest [skip ci]"
-
-      - name: Lint
-        run: npm run lint
-
-      - name: Typecheck
-        run: npm run typecheck
-
-      - name: Install Playwright browsers
-        run: npx playwright install chromium
-
-      - name: Test
-        run: npm test
 
       - name: Build package
         run: npm run build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,19 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      # Testpolicy: ingenting publiseres utestet — full kvalitetssjekk før versjonsbump.
+      - name: Lint
+        run: npm run lint
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Install Playwright browsers
+        run: npx playwright install chromium
+
+      - name: Test (full regression before release)
+        run: npm test
+
       - name: Build package
         run: npm run build
 

--- a/README.md
+++ b/README.md
@@ -231,6 +231,14 @@ pnpm build
 pnpm storybook
 ```
 
+## Testing
+
+Testing i dette repoet følger Norges Røde Kors' testpolicy og overordnede teststrategi. Se **[TESTING.md](./TESTING.md)** for testplanen: testnivåer, risikobasert prioritering, kriterier for «klar til produksjon», feilhåndtering og rapportering. Kort versjon:
+
+- Stories er testene: hver komponent testes i ekte nettleser med `play`-assertions og automatisk WCAG-sjekk (brudd feiler bygget).
+- Full regresjon (`npm test`) kjøres på hver pull request og hver push til `main` — ingenting merges eller publiseres utestet.
+- Feil meldes som GitHub Issues med bug-malen; alvorlighetsgrad og reproduksjonssteg er påkrevd.
+
 ## Core Principles
 
 Every component we build should adhere to these core principles:

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,121 @@
+# Testplan — Røde Kors Designsystem
+
+> Denne testplanen følger Norges Røde Kors' testpolicy, overordnede teststrategi og «Testing – prinsipper og praksis». Den beskriver hvordan testing er organisert for designsystemet (`rk-designsystem`).
+>
+> **Testhåndteringssystem:** Organisasjonens dokumenter beskriver Azure DevOps som verktøy. Dette produktet utvikles på **GitHub**, og inntil en eventuell overgang er GitHub vårt testhåndteringssystem: GitHub Actions (kjøring og rapportering), Pull Requests (godkjenning og sporbarhet) og GitHub Issues (feilhåndtering). Prinsippene er de samme — sporbarhet mellom krav, kode og test i ett verktøy.
+
+## 1. Omfang
+
+Testplanen gjelder komponentbiblioteket (`src/components`), designtokens-integrasjonen, Storybook-dokumentasjonen og dokumentasjonsplattformen (`src/pages`). Den dekker all endring som skal publiseres til npm eller deployes til GitHub Pages.
+
+## 2. Roller og ansvar
+
+| Rolle | Ansvar |
+|---|---|
+| Produkteier/maintainer | Godkjenner PR-er (= akseptanse), eier akseptert risiko, prioriterer testinnsats, tildeler feilrettinger |
+| Utviklere (interne og agenter) | Skriver og vedlikeholder story-tester for egne endringer, kjører full suite lokalt før PR |
+| Testleder-funksjonen | Ivaretas av maintainer: vedlikeholder denne planen, overvåker testdekning og risiko |
+| Konsumerende team | Melder feil via GitHub Issues (bug-mal), deltar i akseptansetesting av nye komponenter |
+
+Kvalitet er et felles ansvar; testing er ikke en fase til slutt, men en del av hver endring.
+
+## 3. Testbasis
+
+- Komponentkrav: Storybook-stories og MDX-dokumentasjon per komponent
+- Designgrunnlag: «Design retning»-boarden i Figma og `rk-design-tokens`
+- API-kontrakt: `metadata.json` (genereres fra koden) og `AI_DESIGN_SYSTEM_GUIDE.md`
+- Digdir Designsystemet som underliggende leverandørdokumentasjon
+
+## 4. Testnivåer (jf. praksisguiden kap. 4.1)
+
+| Nivå | Slik gjør vi det | Verktøy |
+|---|---|---|
+| **Enhetstest** | Hver komponent har stories som kjøres som tester i ekte nettleser; interaksjonstester (`play`) verifiserer forventet resultat | Vitest + Storybook addon, headless Chromium (Playwright) |
+| **Integrasjonstest** | Sammensatte komponenter (Header, Footer, Donor, skjema-komposisjoner) testes gjennom sine stories; dokumentasjonsplattformen bygger mot biblioteket | Samme suite + `vite build` |
+| **Systemtest** | Full bygg av npm-pakke, Storybook og docs-app i CI ved hver endring | GitHub Actions |
+| **Akseptansetest (UAT)** | PR-review: reviewer verifiserer endringen i Storybook/localhost før merge. Merge til `main` = godkjenning. Nye komponenter demonstreres for konsumerende team ved behov | GitHub PR + Storybook |
+| **Regresjonstest** | Hele testsuite (alle stories, alle komponenter) kjøres på **hver PR** og hver push til `main` — ikke bare det som er endret | GitHub Actions |
+
+## 5. Testtyper (jf. praksisguiden kap. 4.2)
+
+- **Funksjonell testing:** `play`-assertions i stories (klikk, tastatur, tilstander, forventet resultat).
+- **Tilgjengelighet (ikke-funksjonell):** `@storybook/addon-a11y` med `test: 'error'` — WCAG-brudd **feiler** testkjøringen. Dette er vårt viktigste ikke-funksjonelle krav (universell utforming).
+- **Visuell testing:** Manuell verifisering i Storybook (lys/mørk modus, tre brand-varianter) som del av PR-review. Skjermbilder i PR-beskrivelsen ved visuelle endringer.
+- **Negativ testing:** Stories skal dekke feiltilstander (disabled, error, tomme verdier) der komponenten har dem.
+- **Sikkerhetstesting:** `npm audit` og Dependabot for avhengigheter; ingen egenutviklet autentisering/datalagring i biblioteket (se «avgrensninger»). Peer-avhengigheter eksternaliseres slik at konsumenter styrer sine versjoner.
+- **Typesikkerhet:** `tsc --noEmit` (strict) og publisert `.d.ts` er del av kontraktstestingen mot konsumenter.
+
+## 6. Testmiljøer
+
+| Miljø | Bruk |
+|---|---|
+| Lokalt (`npm run storybook` / `npm run dev`) | Utvikling og utforskende testing |
+| CI (GitHub Actions, headless Chromium) | Automatisert kjøring av hele suiten |
+| GitHub Pages (Storybook + docs) | «Staging»/demonstrasjon — alltid siste `main` |
+| npm-pakken | Produksjon — kun publisert via release-workflow |
+
+## 7. Testdata
+
+Alle stories bruker **syntetiske, fiktive data** (navn som «Frodo Baggins», e-poster som `test@test.no`). Det skal aldri brukes reelle personopplysninger i stories, tester eller dokumentasjon (GDPR). Testdata skal dekke normaltilfeller og kanttilfeller (lange strenger, tomme verdier, ugyldig input) der komponenten håndterer input.
+
+## 8. Risikobasert prioritering (jf. praksisguiden kap. 12)
+
+Testinnsatsen prioriteres der feil gjør mest skade. Vurdering per område:
+
+| Område | Konsekvens | Sannsynlighet | Risiko | Testtiltak |
+|---|---|---|---|---|
+| Skjemakomponenter (Input, Select, Checkbox, Radio, DatePicker, DateInput) | Høy (brukere får ikke fullført oppgaver) | Middels | **Høy** | Interaksjonstester, negativ testing, a11y |
+| Header/Footer (alle flater) | Høy (synlig overalt) | Middels | **Høy** | Interaksjonstester, responsiv + mørk modus-verifisering |
+| Donor (donasjonsflyt) | Høy (økonomi/omdømme) | Middels | **Høy** | Interaksjonstester på beløpsvalg og callbacks |
+| Tokens-integrasjon (`rk-design-tokens`) | Høy (endrer alt visuelt) | Middels (auto-oppdateres i CI) | **Høy** | Full regresjon kjøres ved hver token-bump; visuell sjekk ved major-endringer |
+| Visningskomponenter (Tag, Badge, Avatar, …) | Lav–middels | Lav | Lav | Render- og a11y-tester |
+| Dokumentasjonsplattformen (`src/pages`) | Lav (publiseres ikke til npm) | Middels | Middels | Typecheck/lint + manuell verifisering |
+
+**Akseptert risiko** (bevisste valg, jf. kap. 12.3.2 E):
+- Ingen automatisert visuell regresjon (skjermbilde-diff) — kompenseres med manuell Storybook-review i PR. Begrunnelse: kost/nytte for nåværende teamstørrelse.
+- Ingen ytelsestesting av komponenter — lav last, statiske komponenter.
+- Dokumentasjonsplattformen har ikke egne automatiserte tester — lav konsekvens, dekkes av typecheck og manuell review.
+
+Når testing begrenses utover dette skal det dokumenteres i PR-beskrivelsen med begrunnelse.
+
+## 9. Kriterier
+
+**«Klar til test» (før PR åpnes):**
+- [ ] Typecheck og lint er grønne lokalt
+- [ ] Endret/ny funksjonalitet har stories (enhetstest)
+- [ ] Full testsuite er kjørt lokalt (regresjon)
+
+**«Klar til produksjon» (før merge/release):**
+- [ ] Alle CI-sjekker er grønne (lint, typecheck, full testsuite, bygg av pakke + Storybook)
+- [ ] PR er godkjent av maintainer (akseptanse)
+- [ ] Kjente feil er dokumentert som Issues; akseptert risiko står i PR-beskrivelsen
+- [ ] Breaking changes er flagget (`!` i commit / PR-tittel) og beskrevet
+- [ ] AI-kontekstartefakter er regenerert ved API-endringer (`metadata.json`, guide, manifest)
+
+**Produksjonssetting (npm-release):**
+- [ ] Release-workflow kjøres kun fra grønn `main`
+- [ ] Versjonsbump følger semver (breaking = major)
+- [ ] Rollback-plan: `npm deprecate` av defekt versjon + ny patch; GitHub Pages redeployes fra forrige grønne `main`
+- [ ] Verifisering etter publisering: installer pakken i et konsumentprosjekt eller kjør `npm pack`-sjekk
+
+## 10. Feilhåndtering (jf. praksisguiden kap. 9.4)
+
+Feil registreres som **GitHub Issues med bug-malen** (`.github/ISSUE_TEMPLATE/bug_report.yml`). Malen krever: tydelig tittel, faktisk og forventet resultat, steg for å reprodusere, alvorlighetsgrad, versjon og skjermbilde ved visuelle feil. Retting kobles til issuen via `Fixes #N` i PR-en — det gir sporbarheten krav → feil → test → fiks.
+
+Alvorlighetsgrader:
+- **Kritisk** — komponent ubrukelig, sikkerhets- eller tilgjengelighetsbrudd, feil i produksjon hos konsumenter
+- **Høy** — vesentlig funksjonalitet feiler, workaround finnes
+- **Middels** — feil med enkel workaround
+- **Lav** — kosmetisk
+
+## 11. Rapportering (jf. teststrategien kap. 7)
+
+- **Teststatus og -resultater:** GitHub Actions-kjøringen på hver PR og hver push er testrapporten — den viser hva som er kjørt, hva som passerte og hva som feilet, med historikk over tid.
+- **Sluttrapport per release:** GitHub Release-notatene oppsummerer endringer; CHANGELOG.md vedlikeholdes automatisk av release-workflowen. Kjente avvik og akseptert risiko refereres fra release-notatene ved behov.
+- **Trend:** Actions-historikken gir utvikling over tid (antall kjøringer, feilrate).
+
+## 12. Kompetanse og forbedring (jf. praksisguiden kap. 15)
+
+- Nye bidragsytere leser denne planen og README-ens bidragsguide før første PR.
+- Testfunn som avdekker mønstre (f.eks. gjentatte a11y-feil) skal føre til oppdatering av denne planen eller av komponent-retningslinjene.
+- Planen revideres ved større endringer i verktøy eller organisering (f.eks. en eventuell overgang til Azure DevOps).

--- a/src/components/Heading/Heading.stories.tsx
+++ b/src/components/Heading/Heading.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
+import { Heading } from './index';
+
+const meta: Meta<typeof Heading> = {
+  title: 'Components/Heading',
+  component: Heading,
+  tags: ['autodocs'],
+  argTypes: {
+    level: {
+      control: 'select',
+      options: [1, 2, 3, 4, 5, 6],
+      description: 'Semantic heading level (required)',
+    },
+    'data-size': {
+      control: 'select',
+      options: ['2xs', 'xs', 'sm', 'md', 'lg', 'xl', '2xl'],
+      description: 'Visual size, independent of semantic level',
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Heading>;
+
+export const Default: Story = {
+  args: {
+    level: 2,
+    children: 'En overskrift',
+  },
+};
+
+export const AllLevels: Story = {
+  render: () => (
+    <>
+      <Heading level={1} data-size="xl">Nivå 1</Heading>
+      <Heading level={2} data-size="lg">Nivå 2</Heading>
+      <Heading level={3} data-size="md">Nivå 3</Heading>
+      <Heading level={4} data-size="sm">Nivå 4</Heading>
+      <Heading level={5} data-size="xs">Nivå 5</Heading>
+      <Heading level={6} data-size="2xs">Nivå 6</Heading>
+    </>
+  ),
+};
+
+// --- INTERACTION TESTS ---
+
+export const TestSemanticLevel: Story = {
+  name: 'Test: Semantic Level',
+  args: {
+    level: 2,
+    'data-size': 'lg',
+    children: 'Semantisk overskrift',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // The visual size must not change the semantic level
+    const heading = canvas.getByRole('heading', { level: 2, name: 'Semantisk overskrift' });
+    expect(heading).toBeInTheDocument();
+    expect(heading.tagName).toBe('H2');
+  },
+};

--- a/src/components/Label/Label.stories.tsx
+++ b/src/components/Label/Label.stories.tsx
@@ -1,0 +1,61 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
+import { Label } from './index';
+import { Input } from '../Input';
+
+const meta: Meta<typeof Label> = {
+  title: 'Components/Label',
+  component: Label,
+  tags: ['autodocs'],
+  argTypes: {
+    'data-size': {
+      control: 'select',
+      options: ['xs', 'sm', 'md', 'lg', 'xl'],
+      description: 'Text size',
+    },
+    weight: {
+      control: 'select',
+      options: ['regular', 'medium', 'semibold'],
+      description: 'Font weight',
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Label>;
+
+export const Default: Story = {
+  args: {
+    children: 'Fullt navn',
+  },
+};
+
+export const WithInput: Story = {
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--ds-size-2)' }}>
+      <Label htmlFor="label-demo-input">E-postadresse</Label>
+      <Input id="label-demo-input" type="email" />
+    </div>
+  ),
+};
+
+// --- INTERACTION TESTS ---
+
+export const TestLabelsInput: Story = {
+  name: 'Test: Labels Input',
+  render: () => (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--ds-size-2)' }}>
+      <Label htmlFor="label-test-input">Telefonnummer</Label>
+      <Input id="label-test-input" type="tel" />
+    </div>
+  ),
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    // The label must be programmatically associated with the input
+    const input = canvas.getByLabelText('Telefonnummer');
+    expect(input).toBeInTheDocument();
+    expect(input.tagName).toBe('INPUT');
+  },
+};

--- a/src/components/Paragraph/Paragraph.stories.tsx
+++ b/src/components/Paragraph/Paragraph.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
+import { Paragraph } from './index';
+
+const meta: Meta<typeof Paragraph> = {
+  title: 'Components/Paragraph',
+  component: Paragraph,
+  tags: ['autodocs'],
+  argTypes: {
+    'data-size': {
+      control: 'select',
+      options: ['xs', 'sm', 'md', 'lg', 'xl'],
+      description: 'Text size',
+    },
+    variant: {
+      control: 'select',
+      options: ['default', 'long'],
+      description: 'Variant tuned for short or long-form text',
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Paragraph>;
+
+export const Default: Story = {
+  args: {
+    children: 'Røde Kors hjelper mennesker i sårbare livssituasjoner — lokalt, nasjonalt og internasjonalt.',
+  },
+};
+
+export const Sizes: Story = {
+  render: () => (
+    <>
+      <Paragraph data-size="xs">Ekstra liten tekst</Paragraph>
+      <Paragraph data-size="sm">Liten tekst</Paragraph>
+      <Paragraph data-size="md">Medium tekst</Paragraph>
+      <Paragraph data-size="lg">Stor tekst</Paragraph>
+    </>
+  ),
+};
+
+// --- INTERACTION TESTS ---
+
+export const TestRendersText: Story = {
+  name: 'Test: Renders Text',
+  args: {
+    children: 'Avsnittstekst',
+    'data-size': 'md',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const paragraph = canvas.getByText('Avsnittstekst');
+    expect(paragraph).toBeInTheDocument();
+    expect(paragraph.tagName).toBe('P');
+  },
+};

--- a/src/components/ValidationMessage/ValidationMessage.stories.tsx
+++ b/src/components/ValidationMessage/ValidationMessage.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
+import { ValidationMessage } from './index';
+
+const meta: Meta<typeof ValidationMessage> = {
+  title: 'Components/ValidationMessage',
+  component: ValidationMessage,
+  tags: ['autodocs'],
+  argTypes: {
+    'data-size': {
+      control: 'select',
+      options: ['xs', 'sm', 'md', 'lg'],
+      description: 'Text size',
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ValidationMessage>;
+
+export const Default: Story = {
+  args: {
+    children: 'Feltet er påkrevd.',
+  },
+};
+
+export const LongMessage: Story = {
+  args: {
+    children: 'E-postadressen er ikke gyldig. Kontroller at adressen er skrevet riktig, for eksempel navn@example.com.',
+  },
+};
+
+// --- INTERACTION TESTS ---
+
+export const TestRendersMessage: Story = {
+  name: 'Test: Renders Message',
+  args: {
+    children: 'Passordet må være minst 8 tegn.',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    const message = canvas.getByText('Passordet må være minst 8 tegn.');
+    expect(message).toBeInTheDocument();
+  },
+};


### PR DESCRIPTION
## Summary

Aligns the repo with **Testpolicy for Norges Røde Kors**, **Overordnet teststrategi** and **Testing – prinsipper og praksis**, adapted to GitHub (we are not on Azure DevOps yet — GitHub Actions, PRs and Issues serve as the test management system, stated explicitly in the plan).

### What this adds

- **`TESTING.md`** — the repo's testplan following the org template: test levels (enhet/integrasjon/system/UAT/regresjon) mapped to how this repo actually tests, test types incl. a11y-as-blocking, roles, testbasis, environments, GDPR-safe test data, **risk-based prioritization with a risk matrix and explicitly documented accepted risk**, klar-til-test / klar-til-produksjon criteria, bug severity model, and reporting via Actions history.
- **CI gate on pull requests** — the full suite (lint, typecheck, all story tests + a11y, package/Storybook/app builds) now runs on every PR. Previously tests only ran *after* merge, on push to main. («Test tidlig og kontinuerlig», «testing skal dokumenteres».)
- **Token auto-update tested before commit/deploy** — the `npm update rk-design-tokens` step previously auto-committed to main *before* tests ran; it now runs the full regression first. («Alle løsninger … skal være testet og godkjent … før produksjonssetting.»)
- **Release workflow tests before `npm publish`** — full regression added ahead of the version bump.
- **Bug report template** with severity, steps, expected/actual, version (praksisguiden kap. 9.4) and **PR template** with the test checklist incl. accepted-risk section (kap. 10, 12.3).
- **Four previously untested components now have story tests with play-assertions**: Heading, Label, Paragraph, ValidationMessage — production code shipped with zero coverage violated the policy. 47→51 test files, 294→306 tests.

### Known gaps (documented as accepted risk in TESTING.md)

No automated visual regression, no performance testing, docs app covered by typecheck + manual review only — each with rationale, per kap. 12.3.2 E.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors (10 pre-existing warnings)
- [x] `npm test` — 306 tests / 51 files pass incl. the 4 new story files
- [ ] CI on this very PR demonstrates the new PR gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)