### PR TITLE
feat(docs)!: redesign documentation platform to the Design retning direction

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -80,18 +80,28 @@ function App() {
       </div>
 
       <Footer
-        data-color="neutral"
+        variant="columns"
+        data-color="primary"
+        colorScheme="dark"
         showCrossCorners={false}
         hideNewsletter={true}
-        shortcutsLinks={[
-          { label: t('header.nav.components'), href: '#components' },
-          { label: t('header.nav.design'), href: '#design' },
-          { label: t('header.nav.code'), href: '#code' },
-          { label: t('header.nav.tokens'), href: '#tokens' }
-        ]}
-        linksLinks={[
-          { label: 'GitHub', href: 'https://github.com/norwegianredcross/DesignSystem' },
-          { label: 'Storybook', href: 'https://norwegianredcross.github.io/DesignSystem/storybook' }
+        columns={[
+          {
+            title: t('footer.shortcuts'),
+            links: [
+              { label: t('header.nav.design'), href: '#design' },
+              { label: t('header.nav.components'), href: '#components' },
+              { label: t('header.nav.code'), href: '#code' },
+              { label: t('header.nav.tokens'), href: '#tokens' }
+            ]
+          },
+          {
+            title: 'Lenker',
+            links: [
+              { label: 'GitHub', href: 'https://github.com/norwegianredcross/DesignSystem' },
+              { label: 'Storybook', href: 'https://norwegianredcross.github.io/DesignSystem/storybook' }
+            ]
+          }
         ]}
       />
     </div>

--- a/src/components/ArticleLayout/index.tsx
+++ b/src/components/ArticleLayout/index.tsx
@@ -23,13 +23,13 @@ export const ArticleLayout = ({ title, intro, category, children }: ArticleLayou
         {category}
       </div>
     )}
-    <Heading level={1} data-size="xl" style={{ marginBottom: 'var(--ds-size-4)' }}>{title}</Heading>
+    <Heading level={1} data-size="xl" style={{ marginBottom: 'var(--ds-size-4)', color: 'var(--ds-color-primary-color-red-text-default)' }}>{title}</Heading>
     {intro && (
-      <Paragraph data-size="lg" style={{ color: 'var(--ds-color-neutral-text-subtle)', marginBottom: 'var(--ds-size-8)' }}>
+      <Paragraph data-size="lg" style={{ color: 'var(--ds-color-primary-color-red-text-default)', marginBottom: 'var(--ds-size-6)' }}>
         {intro}
       </Paragraph>
     )}
-    <hr style={{ border: 0, borderBottom: '1px solid var(--ds-color-neutral-border-subtle)', marginBottom: 'var(--ds-size-10)' }} />
+    <hr style={{ border: 0, borderTop: '2px solid var(--ds-color-primary-color-red-base-default)', width: 'var(--ds-size-30)', marginLeft: 0, marginBottom: 'var(--ds-size-10)' }} />
     {children}
   </div>
 );

--- a/src/pages/Code/index.tsx
+++ b/src/pages/Code/index.tsx
@@ -1,11 +1,12 @@
 import { useState } from 'react';
+import { ArrowRightIcon } from '@navikt/aksel-icons';
 import { useLanguage } from '../../context/LanguageContext';
 import { Heading } from '../../components/Heading';
 import { Paragraph } from '../../components/Paragraph';
 import { List } from '../../components/List';
 import { Link } from '../../components/Link';
 import { Card, CardBlock } from '../../components/Card';
-import { ArticleLayout, ArticleImage } from '../../components/ArticleLayout';
+import { ArticleImage } from '../../components/ArticleLayout';
 import styles from './styles.module.css';
 
 // --- CONTENT COMPONENTS ---
@@ -16,10 +17,28 @@ const CodeBlock = ({ children, style, className }: { children: React.ReactNode; 
   </pre>
 );
 
+/**
+ * Article shell for doc sections: category kicker, maroon display heading,
+ * maroon ingress followed by a thin red rule (design retning article pattern).
+ */
+const DocArticle = ({ title, intro, category, children }: { title: string; intro?: string; category?: string; children?: React.ReactNode }) => (
+  <article className="article-max-width animate-fade-in">
+    {category && <div className={styles.kicker}>{category}</div>}
+    <Heading level={1} data-size="xl" className={styles.articleTitle}>{title}</Heading>
+    {intro && (
+      <>
+        <Paragraph data-size="lg" className={styles.ingress}>{intro}</Paragraph>
+        <hr className={styles.leadRule} />
+      </>
+    )}
+    {children}
+  </article>
+);
+
 const OverviewContent = ({ setActivePage }: { setActivePage: (page: string) => void }) => {
   const { t } = useLanguage();
   return (
-    <ArticleLayout title={t('code.overview.title')} intro={t('code.overview.intro')} category={t('code.sidebar.overview')}>
+    <DocArticle title={t('code.overview.title')} intro={t('code.overview.intro')} category={t('code.sidebar.overview')}>
       <Paragraph style={{ marginBottom: 'var(--ds-size-4)' }}>
         {t('code.overview.text1')}
       </Paragraph>
@@ -31,36 +50,36 @@ const OverviewContent = ({ setActivePage }: { setActivePage: (page: string) => v
       </Paragraph>
 
       <div className={styles.introGrid}>
-        <Card variant="tinted" data-color="neutral">
+        <Card variant="tinted" data-color="neutral" className={styles.introCard}>
           <CardBlock>
             <Heading level={3} data-size="sm">{t('code.overview.getStartedCard')}</Heading>
             <Paragraph data-size="sm" style={{ marginBottom: 'var(--ds-size-2)' }}>{t('code.overview.getStartedDesc')}</Paragraph>
-            <Link href="https://github.com/norwegianredcross/DesignSystem" target="_blank" rel="noopener noreferrer">{t('code.overview.getStartedLink')}</Link>
+            <Link href="https://github.com/norwegianredcross/DesignSystem" target="_blank" rel="noopener noreferrer" className={styles.arrowLink}>{t('code.overview.getStartedLink')} <ArrowRightIcon aria-hidden /></Link>
           </CardBlock>
         </Card>
-        <Card variant="tinted" data-color="neutral">
+        <Card variant="tinted" data-color="neutral" className={styles.introCard}>
           <CardBlock>
             <Heading level={3} data-size="sm">{t('code.overview.designTokensCard')}</Heading>
             <Paragraph data-size="sm" style={{ marginBottom: 'var(--ds-size-2)' }}>{t('code.overview.designTokensDesc')}</Paragraph>
-            <Link href="#" onClick={(e) => {e.preventDefault(); setActivePage('design-tokens')}}>{t('code.overview.designTokensLink')}</Link>
+            <Link href="#" onClick={(e) => {e.preventDefault(); setActivePage('design-tokens')}} className={styles.arrowLink}>{t('code.overview.designTokensLink')} <ArrowRightIcon aria-hidden /></Link>
           </CardBlock>
         </Card>
-        <Card variant="tinted" data-color="neutral">
+        <Card variant="tinted" data-color="neutral" className={styles.introCard}>
           <CardBlock>
             <Heading level={3} data-size="sm">{t('code.overview.workflowCard')}</Heading>
             <Paragraph data-size="sm" style={{ marginBottom: 'var(--ds-size-2)' }}>{t('code.overview.workflowDesc')}</Paragraph>
-            <Link href="#" onClick={(e) => {e.preventDefault(); setActivePage('figma-mcp')}}>{t('code.overview.workflowLink')}</Link>
+            <Link href="#" onClick={(e) => {e.preventDefault(); setActivePage('figma-mcp')}} className={styles.arrowLink}>{t('code.overview.workflowLink')} <ArrowRightIcon aria-hidden /></Link>
           </CardBlock>
         </Card>
       </div>
-    </ArticleLayout>
+    </DocArticle>
   );
 };
 
 const GettingStartedContent = () => {
   const { t } = useLanguage();
   return (
-    <ArticleLayout title={t('code.getStarted.title')} category={t('code.sidebar.overview')}>
+    <DocArticle title={t('code.getStarted.title')} category={t('code.sidebar.overview')}>
       <Paragraph style={{ marginBottom: 'var(--ds-size-4)' }}>
         {t('code.getStarted.intro')}
       </Paragraph>
@@ -185,14 +204,14 @@ export default function Home() {
         {t('code.getStarted.updateText')}
       </Paragraph>
       <CodeBlock>npm update rk-design-tokens</CodeBlock>
-    </ArticleLayout>
+    </DocArticle>
   );
 };
 
 const DesignTokensContent = () => {
   const { t } = useLanguage();
   return (
-    <ArticleLayout title={t('code.designTokens.title')} category={t('code.sidebar.overview')}>
+    <DocArticle title={t('code.designTokens.title')} category={t('code.sidebar.overview')}>
       <Paragraph style={{ marginBottom: 'var(--ds-size-4)' }}>
         {t('code.designTokens.intro')}
       </Paragraph>
@@ -258,14 +277,14 @@ export default function RootLayout({ children }) {
         <List.Item><strong>{t('code.designTokens.phase3Item4').split(':')[0]}:</strong> {t('code.designTokens.phase3Item4').split(':').slice(1).join(':').trim()}</List.Item>
       </List.Unordered>
       
-    </ArticleLayout>
+    </DocArticle>
   );
 };
 
 const FontsContent = () => {
   const { t } = useLanguage();
   return (
-    <ArticleLayout title={t('code.fonts.title')} category={t('code.sidebar.overview')}>
+    <DocArticle title={t('code.fonts.title')} category={t('code.sidebar.overview')}>
       <Paragraph style={{ marginBottom: 'var(--ds-size-4)' }}>
         {t('code.fonts.intro')}
       </Paragraph>
@@ -284,7 +303,7 @@ const FontsContent = () => {
       <Paragraph style={{ marginBottom: 'var(--ds-size-2)' }}>
         {t('code.fonts.nextjsText')}
       </Paragraph>
-      <Paragraph style={{ marginBottom: 'var(--ds-size-4)', fontWeight: 'bold', color: 'var(--ds-color-danger-base-default)' }}>
+      <Paragraph className={styles.callout} style={{ marginBottom: 'var(--ds-size-4)' }}>
         {t('code.fonts.classNameWarning')}
       </Paragraph>
       <CodeBlock>
@@ -342,14 +361,14 @@ export default function App({ Component, pageProps }: AppProps) {
       <Paragraph>
         {t('code.fonts.cssVariablesText')}
       </Paragraph>
-    </ArticleLayout>
+    </DocArticle>
   );
 };
 
 const IconsContent = () => {
   const { t } = useLanguage();
   return (
-    <ArticleLayout title={t('code.icons.title')} category={t('code.sidebar.overview')}>
+    <DocArticle title={t('code.icons.title')} category={t('code.sidebar.overview')}>
       <Paragraph style={{ marginBottom: 'var(--ds-size-4)' }}>
         {t('code.icons.intro')}
       </Paragraph>
@@ -403,14 +422,14 @@ export function IconsExample() {
       <Paragraph>
         {t('code.icons.performanceText')}
       </Paragraph>
-    </ArticleLayout>
+    </DocArticle>
   );
 };
 
 const ContributingContent = () => {
   const { t } = useLanguage();
   return (
-    <ArticleLayout title={t('code.contributing.title')} category={t('code.sidebar.contribute')}>
+    <DocArticle title={t('code.contributing.title')} category={t('code.sidebar.contribute')}>
       <Paragraph style={{ marginBottom: 'var(--ds-size-4)' }}>
         {t('code.contributing.intro')}
       </Paragraph>
@@ -521,14 +540,14 @@ pnpm storybook`}
             </ul>
         </List.Item>
       </List.Ordered>
-    </ArticleLayout>
+    </DocArticle>
   );
 };
 
 const FigmaMcpIntroContent = () => {
   const { t } = useLanguage();
   return (
-    <ArticleLayout title={t('code.figmaMcp.introTitle')} category={t('code.sidebar.workflow')}>
+    <DocArticle title={t('code.figmaMcp.introTitle')} category={t('code.sidebar.workflow')}>
       <Paragraph style={{ marginBottom: 'var(--ds-size-6)' }}>
         {t('code.figmaMcp.intro')}
       </Paragraph>
@@ -598,14 +617,14 @@ const FigmaMcpIntroContent = () => {
         <List.Item>{t('code.figmaMcp.nextStepsItem1')}</List.Item>
         <List.Item>{t('code.figmaMcp.nextStepsItem2')}</List.Item>
       </List.Unordered>
-    </ArticleLayout>
+    </DocArticle>
   );
 };
 
 const FigmaMcpCursorContent = () => {
   const { t } = useLanguage();
   return (
-    <ArticleLayout title={t('code.figmaMcp.cursorWorkflowTitle')} category={t('code.sidebar.workflow')}>
+    <DocArticle title={t('code.figmaMcp.cursorWorkflowTitle')} category={t('code.sidebar.workflow')}>
       <Paragraph style={{ marginBottom: 'var(--ds-size-6)' }}>
         {t('code.figmaMcp.cursorWorkflowIntro')}
       </Paragraph>
@@ -811,14 +830,14 @@ const FigmaMcpCursorContent = () => {
         <List.Item>{t('code.figmaMcp.proTip1')}</List.Item>
         <List.Item>{t('code.figmaMcp.proTip2')}</List.Item>
       </List.Unordered>
-    </ArticleLayout>
+    </DocArticle>
   );
 };
 
 const FigmaMcpClaudeContent = () => {
   const { t } = useLanguage();
   return (
-    <ArticleLayout title={t('code.figmaMcp.claudeWorkflowTitle')} category={t('code.sidebar.workflow')}>
+    <DocArticle title={t('code.figmaMcp.claudeWorkflowTitle')} category={t('code.sidebar.workflow')}>
       <Paragraph style={{ marginBottom: 'var(--ds-size-6)' }}>
         {t('code.figmaMcp.claudeWorkflowIntro')}
       </Paragraph>
@@ -989,14 +1008,14 @@ const FigmaMcpClaudeContent = () => {
         <List.Item>{t('code.figmaMcp.step0_5WhyItem4')}</List.Item>
         <List.Item>{t('code.figmaMcp.step0_5WhyItem5')}</List.Item>
       </List.Unordered>
-    </ArticleLayout>
+    </DocArticle>
   );
 };
 
 const MetadataFilesContent = () => {
   const { t } = useLanguage();
   return (
-    <ArticleLayout title={t('code.metadataFiles.title')} category={t('code.sidebar.structure')}>
+    <DocArticle title={t('code.metadataFiles.title')} category={t('code.sidebar.structure')}>
       <Paragraph style={{ marginBottom: 'var(--ds-size-4)' }}>
         {t('code.metadataFiles.intro')}
       </Paragraph>
@@ -1023,14 +1042,14 @@ const MetadataFilesContent = () => {
       <Paragraph>
         {t('code.metadataFiles.howText')}
       </Paragraph>
-    </ArticleLayout>
+    </DocArticle>
   );
 };
 
 const KomponentKreasjonContent = () => {
   const { t } = useLanguage();
   return (
-    <ArticleLayout title={t('code.componentCreation.title')} category={t('code.sidebar.workflow')}>
+    <DocArticle title={t('code.componentCreation.title')} category={t('code.sidebar.workflow')}>
       <Paragraph style={{ marginBottom: 'var(--ds-size-6)' }}>
         {t('code.componentCreation.intro')}
       </Paragraph>
@@ -1097,7 +1116,7 @@ const KomponentKreasjonContent = () => {
         <List.Item><strong>{t('code.componentCreation.benefit3').split(':')[0]}:</strong> {t('code.componentCreation.benefit3').split(':').slice(1).join(':').trim()}</List.Item>
         <List.Item><strong>{t('code.componentCreation.benefit4').split(':')[0]}:</strong> {t('code.componentCreation.benefit4').split(':').slice(1).join(':').trim()}</List.Item>
       </List.Unordered>
-    </ArticleLayout>
+    </DocArticle>
   );
 };
 

--- a/src/pages/Code/styles.module.css
+++ b/src/pages/Code/styles.module.css
@@ -6,6 +6,7 @@
   align-items: flex-start;
 }
 
+/* Sidebar as a soft cream panel (same treatment as the Design page) */
 .sidebar {
   width: 280px;
   flex-shrink: 0;
@@ -15,8 +16,10 @@
   max-height: calc(100vh - var(--ds-size-12));
   overflow-y: auto;
   overflow-x: hidden;
-  padding-right: var(--ds-size-4);
-  padding-top: var(--ds-size-10);
+  margin-top: var(--ds-size-10);
+  padding: var(--ds-size-6) var(--ds-size-4);
+  background: var(--ds-color-neutral-background-tinted);
+  border-radius: var(--ds-border-radius-xl);
 }
 
 /* Custom Scrollbar for Sidebar */
@@ -42,15 +45,15 @@
   flex-direction: column;
 }
 
+/* Group titles: maroon, semibold — page-level wayfinding (as on Design) */
 .groupTitle {
-  font-size: var(--ds-font-size-sm, 14px);
-  font-weight: var(--ds-font-weight-bold, 700);
-  color: var(--ds-color-neutral-text-subtle, #5d5d5d);
+  font-size: var(--ds-font-size-2);
+  font-weight: var(--ds-font-weight-semibold);
+  color: var(--ds-color-primary-color-red-text-default);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  margin-bottom: var(--ds-size-2, 8px);
-  padding-left: var(--ds-size-3, 12px);
-  border-left: 4px solid var(--ds-color-primary-color-red-base-default);
+  margin-bottom: var(--ds-size-2);
+  padding-left: var(--ds-size-3);
 }
 
 .list {
@@ -72,7 +75,7 @@
   font-size: var(--ds-font-size-md);
   color: var(--ds-color-neutral-text-default);
   text-decoration: none;
-  border-radius: var(--ds-border-radius-md);
+  border-radius: var(--ds-border-radius-full);
   transition: all 0.2s ease;
   background: transparent;
   border: none;
@@ -82,14 +85,19 @@
 }
 
 .link:hover {
-  background-color: var(--ds-color-neutral-surface-hover);
+  background-color: var(--ds-color-neutral-background-default);
   color: var(--ds-color-neutral-text-default);
 }
 
 .linkActive {
-  background-color: var(--ds-color-primary-surface-subtle);
-  color: var(--ds-color-primary-text-default);
+  background-color: var(--ds-color-primary-color-red-surface-tinted);
+  color: var(--ds-color-primary-color-red-text-default);
   font-weight: var(--ds-font-weight-medium);
+}
+
+.linkActive:hover {
+  background-color: var(--ds-color-primary-color-red-surface-hover);
+  color: var(--ds-color-primary-color-red-text-default);
 }
 
 .details > summary {
@@ -107,7 +115,7 @@
   gap: 1px;
   padding-left: var(--ds-size-3);
   margin-top: 2px;
-  border-left: 1px solid var(--ds-color-neutral-border-subtle);
+  border-left: 1px solid var(--ds-color-primary-color-red-border-subtle);
   margin-left: var(--ds-size-3);
 }
 
@@ -119,23 +127,23 @@
 
 .nestedLink:hover {
   color: var(--ds-color-neutral-text-default);
-  background-color: var(--ds-color-neutral-surface-hover);
+  background-color: var(--ds-color-neutral-background-default);
 }
 
 .nestedLinkActive {
-  color: var(--ds-color-primary-text-default);
-  background-color: var(--ds-color-primary-surface-subtle);
+  color: var(--ds-color-primary-color-red-text-default);
+  background-color: var(--ds-color-primary-color-red-surface-tinted);
   font-weight: var(--ds-font-weight-medium);
-  border-left: 2px solid var(--ds-color-primary-base-default);
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-  margin-left: -1px; /* Overlap border */
+}
+
+.nestedLinkActive:hover {
+  color: var(--ds-color-primary-color-red-text-default);
+  background-color: var(--ds-color-primary-color-red-surface-hover);
 }
 
 .docContent {
   flex: 1;
   padding-left: var(--ds-size-10);
-  border-left: 1px solid var(--ds-color-neutral-border-subtle);
   min-width: 0;
   padding-top: var(--ds-size-18);
 }
@@ -149,9 +157,9 @@
   display: none;
   width: 100%;
   padding: var(--ds-size-3) var(--ds-size-4);
-  background: var(--ds-color-neutral-surface-tinted);
+  background: var(--ds-color-neutral-background-tinted);
   border: 1px solid var(--ds-color-neutral-border-subtle);
-  border-radius: var(--ds-border-radius-md);
+  border-radius: var(--ds-border-radius-lg);
   font-family: inherit;
   font-size: var(--ds-font-size-md);
   font-weight: var(--ds-font-weight-medium);
@@ -215,8 +223,8 @@
 
 .codeBlock {
   background-color: var(--ds-color-neutral-background-subtle);
-  padding: var(--ds-size-4);
-  border-radius: var(--ds-border-radius-md);
+  padding: var(--ds-size-4) var(--ds-size-5);
+  border-radius: var(--ds-border-radius-lg);
   font-family: monospace;
   font-size: var(--ds-font-size-sm);
   overflow-x: auto;
@@ -224,4 +232,86 @@
   white-space: pre-wrap;
   border: 1px solid var(--ds-color-neutral-border-subtle);
   color: var(--ds-color-neutral-text-default);
+}
+
+/* --- Content typography & interaction (design retning) --- */
+
+/* Page-level heading in maroon; sub-heads stay neutral */
+.docContent h1 {
+  color: var(--ds-color-primary-color-red-text-default);
+}
+
+/* Links: maroon underlined, red on hover */
+.docContent a {
+  color: var(--ds-color-primary-color-red-text-default);
+  text-decoration: underline;
+}
+
+.docContent a:hover {
+  color: var(--ds-color-primary-color-red-text-subtle);
+}
+
+/* Arrow text-buttons: maroon text + arrow icon, pink pill on hover */
+.docContent a.arrowLink,
+.arrowLink {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ds-size-2);
+  color: var(--ds-color-primary-color-red-text-default);
+  font-weight: var(--ds-font-weight-medium);
+  text-decoration: none;
+  border-radius: var(--ds-border-radius-full);
+  padding: var(--ds-size-1) var(--ds-size-3);
+  margin-inline-start: calc(-1 * var(--ds-size-3));
+  transition: background-color 0.15s ease;
+}
+
+.docContent a.arrowLink:hover,
+.arrowLink:hover {
+  background-color: var(--ds-color-primary-color-red-surface-hover);
+  color: var(--ds-color-primary-color-red-text-default);
+}
+
+/* Cream panel cards on the overview page (soft xl radius) */
+.introGrid .introCard {
+  background-color: var(--ds-color-neutral-background-tinted);
+  border-color: transparent;
+  border-radius: var(--ds-border-radius-xl);
+}
+
+/* Callout panel: cream surface, xl radius, maroon emphasis */
+.docContent .callout {
+  background-color: var(--ds-color-neutral-background-tinted);
+  border-radius: var(--ds-border-radius-xl);
+  padding: var(--ds-size-4) var(--ds-size-5);
+  color: var(--ds-color-primary-color-red-text-default);
+  font-weight: var(--ds-font-weight-semibold);
+}
+
+/* Article shell (design retning article pattern: kicker, maroon title,
+   maroon ingress, thin red lead rule) */
+.kicker {
+  font-size: var(--ds-font-size-2);
+  font-weight: var(--ds-font-weight-semibold);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--ds-color-neutral-text-subtle);
+  margin-bottom: var(--ds-size-3);
+}
+
+.articleTitle[class] {
+  color: var(--ds-color-primary-color-red-text-default);
+  margin-bottom: var(--ds-size-4);
+}
+
+.ingress[class] {
+  color: var(--ds-color-primary-color-red-text-default);
+  margin-bottom: var(--ds-size-6);
+}
+
+.leadRule {
+  border: none;
+  border-top: 2px solid var(--ds-color-primary-color-red-base-default);
+  width: var(--ds-size-30);
+  margin: 0 0 var(--ds-size-8);
 }

--- a/src/pages/Components/index.tsx
+++ b/src/pages/Components/index.tsx
@@ -1,23 +1,21 @@
 import { useState, useMemo } from 'react';
+import { ArrowRightIcon } from '@navikt/aksel-icons';
 import { useLanguage } from '../../context/LanguageContext';
 import { Heading } from '../../components/Heading';
 import { Paragraph } from '../../components/Paragraph';
-import { Card, CardBlock } from '../../components/Card';
+import { Card } from '../../components/Card';
+import { Button } from '../../components/Button';
 import styles from './styles.module.css';
 
-export const ComponentsPage = () => {
-  const { t } = useLanguage();
-  const [searchQuery, setSearchQuery] = useState('');
-
-  const components = [
+const components = [
     'Alert', 'Avatar', 'Badge', 'Breadcrumbs', 'Button', 'Card', 'Carousel', 'Checkbox', 'Chip',
     'DateInput', 'DatePicker', 'Details', 'Dialog', 'Divider', 'Dropdown', 'ErrorSummary',
     'Field', 'Fieldset', 'Header', 'HeroSection', 'Input', 'Link', 'List', 'Pagination', 'Popover', 'Radio',
     'Search', 'Select', 'SkeletonLoader', 'SkipLink', 'SpinnerLoader', 'Suggestion',
     'Switch', 'Table', 'Tabs', 'Tag', 'Textarea', 'Textfield', 'ToggleGroup', 'Tooltip'
-  ];
+];
 
-  const iconMap: Record<string, string> = {
+const iconMap: Record<string, string> = {
     Alert: 'alert.svg',
     Avatar: 'avatar.svg',
     Badge: 'badge.svg',
@@ -56,41 +54,46 @@ export const ComponentsPage = () => {
     Textfield: 'textfield.svg',
     ToggleGroup: 'togglegroup.svg',
     Tooltip: 'tooltip.svg',
-  };
+};
+
+export const ComponentsPage = () => {
+  const { t } = useLanguage();
+  const [searchQuery, setSearchQuery] = useState('');
 
   // Filter components based on search query
   const filteredComponents = useMemo(() => {
     return components.filter((comp) =>
       comp.toLowerCase().includes(searchQuery.toLowerCase())
     );
-  }, [components, searchQuery]);
+  }, [searchQuery]);
 
   return (
     <main className={styles.pageWrapper}>
+      {/* Hero: inset rounded cream panel (design retning pattern) */}
       <div className={styles.container}>
-        
-        {/* Header Section */}
-        <div className={styles.header}>
+        <header className={styles.heroPanel}>
           <Heading level={1} className={styles.title}>
             {t('components.title')}
           </Heading>
           <Paragraph className={styles.introText}>
             {t('components.intro')}
           </Paragraph>
-          
+
           {/* Search Input */}
           <div className={styles.searchWrapper}>
-            <input 
-              type="search" 
-              placeholder={t('components.searchPlaceholder')} 
+            <input
+              type="search"
+              placeholder={t('components.searchPlaceholder')}
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
               className={styles.searchInput}
               aria-label={t('components.searchAriaLabel')}
             />
           </div>
-        </div>
+        </header>
+      </div>
 
+      <div className={styles.container}>
         {/* Grid Section */}
         {filteredComponents.length > 0 ? (
           <div className={styles.cardsGrid}>
@@ -101,23 +104,28 @@ export const ComponentsPage = () => {
                   target="_blank"
                   rel="noreferrer"
                 >
-                  <CardBlock>
-                    <div className={styles.cardContent}>
-                      <div className={styles.cardIconWrapper}>
-                        {iconMap[comp] ? (
-                          <img
-                            src={`${import.meta.env.BASE_URL}components/${iconMap[comp]}`}
-                            alt=""
-                            className={styles.cardIcon}
-                            loading="lazy"
-                          />
-                        ) : (
-                          <div className={styles.iconPlaceholder} aria-hidden="true" />
-                        )}
-                      </div>
-                      <Heading level={2} data-size="sm">{comp}</Heading>
-                    </div>
-                  </CardBlock>
+                  <div className={styles.cardMedia}>
+                    {iconMap[comp] ? (
+                      <img
+                        src={`${import.meta.env.BASE_URL}components/${iconMap[comp]}`}
+                        alt=""
+                        className={styles.cardIcon}
+                        loading="lazy"
+                      />
+                    ) : (
+                      <div className={styles.iconPlaceholder} aria-hidden="true" />
+                    )}
+                  </div>
+                  <div className={styles.cardBody}>
+                    <Heading level={2} data-size="sm" className={styles.cardTitle}>
+                      {comp}
+                    </Heading>
+                    <hr className={styles.cardDivider} />
+                    <span className={styles.cardAction}>
+                      {t('components.openLabel')}
+                      <ArrowRightIcon aria-hidden="true" className={styles.cardArrow} />
+                    </span>
+                  </div>
                 </a>
               </Card>
             ))}
@@ -128,6 +136,33 @@ export const ComponentsPage = () => {
             <Paragraph>{t('components.noResults')} "{searchQuery}"</Paragraph>
           </div>
         )}
+
+        {/* Green CTA banner (design retning pattern) */}
+        <aside className={styles.ctaBanner}>
+          <div className={styles.ctaBannerText}>
+            <Heading level={2} data-size="md" className={styles.ctaBannerTitle}>
+              {t('components.ctaTitle')}
+            </Heading>
+            <Paragraph className={styles.ctaBannerBody}>
+              {t('components.ctaText')}
+            </Paragraph>
+          </div>
+          <Button
+            asChild
+            variant="secondary"
+            data-color="main"
+            className={styles.ctaBannerButton}
+          >
+            <a
+              href={`${import.meta.env.BASE_URL}storybook/`}
+              target="_blank"
+              rel="noreferrer"
+            >
+              {t('components.ctaButton')}
+              <ArrowRightIcon aria-hidden="true" />
+            </a>
+          </Button>
+        </aside>
       </div>
     </main>
   );

--- a/src/pages/Components/styles.module.css
+++ b/src/pages/Components/styles.module.css
@@ -1,144 +1,257 @@
-/* Using mapped design tokens from provided CSS 
-*/
+/* Components catalog — "Design retning" restyle.
+   Tokens only: colors/radii/spacing/type all come from rk-design-tokens (--ds-*). */
 
 .pageWrapper {
-    /* Using ds-size-* for vertical rhythm */
-    padding: var(--ds-size-18) 0 var(--ds-size-26);
-    width: 100%;
-    background-color: var(--ds-color-neutral-background-default);
-    min-height: 100vh;
-  }
-  
-  .container {
-    /* Responsive container logic using max-width */
-    width: 100%;
-    max-width: 1200px; 
-    margin: 0 auto;
-    padding-left: var(--ds-size-6);
-    padding-right: var(--ds-size-6);
-  }
-  
-  /* Header Styling */
-  .header {
-    margin-bottom: var(--ds-size-12);
-    display: flex;
-    flex-direction: column;
-    gap: var(--ds-size-4);
-    text-align: center;
-    align-items: center;
-  }
-  
-  .title {
-    color: var(--ds-color-neutral-text-default);
-    /* Typography token application if Heading component doesn't handle it automatically */
-    font-size: var(--ds-heading-xl-font-size);
-    font-weight: var(--ds-heading-xl-font-weight);
-    letter-spacing: var(--ds-heading-xl-letter-spacing);
-  }
-  
-  .introText {
-    color: var(--ds-color-neutral-text-subtle);
-    max-width: 65ch;
-    font-size: var(--ds-body-lg-font-size);
-    line-height: var(--ds-body-lg-line-height);
-  }
-  
-  /* Search Input Styling */
-  .searchWrapper {
-    width: 100%;
-    max-width: 480px;
-    margin-top: var(--ds-size-6);
-  }
-  
-  .searchInput {
-    width: 100%;
-    padding: var(--ds-size-3) var(--ds-size-4);
-    border: var(--ds-border-width-default) solid var(--ds-color-neutral-border-default);
-    border-radius: var(--ds-border-radius-lg); /* Rounded search bar */
-    background-color: var(--ds-color-neutral-background-default);
-    color: var(--ds-color-neutral-text-default);
-    font-size: var(--ds-body-md-font-size);
-    transition: border-color 0.2s ease, box-shadow 0.2s ease;
-  }
-  
-  .searchInput:focus {
-    outline: none;
-    border-color: var(--ds-color-neutral-base-default);
-    box-shadow: 0 0 0 var(--ds-border-width-focus) var(--ds-color-focus-outer);
-  }
-  
-  .searchInput::placeholder {
-    color: var(--ds-color-neutral-text-subtle);
-  }
-  
-  /* Grid Layout */
+  width: 100%;
+  min-height: 100vh;
+  background-color: var(--ds-color-neutral-background-default);
+  padding-bottom: var(--ds-size-26);
+}
+
+.container {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding-left: var(--ds-size-6);
+  padding-right: var(--ds-size-6);
+}
+
+/* Hero: inset rounded cream panel inside the container (design retning pattern) */
+.heroPanel {
+  position: relative;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-size-4);
+  text-align: center;
+  align-items: center;
+  background-color: var(--ds-color-neutral-background-tinted);
+  border-radius: var(--ds-border-radius-xl);
+  padding: var(--ds-size-15) var(--ds-size-10);
+  margin: var(--ds-size-8) 0 var(--ds-size-12);
+}
+
+.title {
+  color: var(--ds-color-primary-color-red-text-default);
+  font-size: var(--ds-font-size-10);
+  font-weight: var(--ds-font-weight-semibold);
+  line-height: var(--ds-line-height-sm);
+}
+
+.introText {
+  color: var(--ds-color-neutral-text-subtle);
+  max-width: 65ch;
+  font-size: var(--ds-font-size-5);
+  line-height: var(--ds-line-height-md);
+}
+
+/* Search input: soft pill on the cream band */
+.searchWrapper {
+  width: 100%;
+  max-width: 480px;
+  margin-top: var(--ds-size-6);
+}
+
+.searchInput {
+  width: 100%;
+  padding: var(--ds-size-3) var(--ds-size-6);
+  border: var(--ds-border-width-default) solid var(--ds-color-neutral-border-subtle);
+  border-radius: var(--ds-border-radius-full);
+  background-color: var(--ds-color-neutral-background-default);
+  color: var(--ds-color-neutral-text-default);
+  font-size: var(--ds-font-size-4);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.searchInput:hover {
+  border-color: var(--ds-color-primary-color-red-border-subtle);
+}
+
+.searchInput:focus {
+  outline: none;
+  border-color: var(--ds-color-primary-color-red-border-subtle);
+  box-shadow: 0 0 0 var(--ds-border-width-focus) var(--ds-color-focus-outer);
+}
+
+.searchInput::placeholder {
+  color: var(--ds-color-neutral-text-subtle);
+}
+
+/* Grid layout */
+.cardsGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(min(220px, 100%), 1fr));
+  gap: var(--ds-size-6);
+}
+
+@media (min-width: 768px) {
   .cardsGrid {
-    display: grid;
-    /* Optimized grid for responsiveness */
-    grid-template-columns: repeat(auto-fill, minmax(min(220px, 100%), 1fr));
-    gap: var(--ds-size-6);
+    gap: var(--ds-size-8);
   }
-  
-  @media (min-width: 768px) {
-    .cardsGrid {
-      gap: var(--ds-size-8);
-    }
+}
+
+@media (max-width: 768px) {
+  .container {
+    padding-left: var(--ds-size-4);
+    padding-right: var(--ds-size-4);
   }
 
-  @media (max-width: 768px) {
-    .container {
-      width: 90%;
-      padding-left: 0;
-      padding-right: 0;
-    }
+  .heroPanel {
+    padding: var(--ds-size-10) var(--ds-size-5);
+    margin-top: var(--ds-size-4);
   }
 
-  /* Card-as-link: layout-only. Visuals (background/border/radius/hover) come
-     from ds-card's native `a` selector now that Card renders as <a> via asChild. */
-  .cardLink {
-    height: 100%;
+  .title {
+    font-size: var(--ds-font-size-8);
+  }
+}
+
+/* Card-as-link: soft cream card, xl radius, pink-tinted border on hover.
+   Doubled class selector so these visuals win over ds-card defaults. */
+.cardLink.cardLink {
+  display: block;
+  height: 100%;
+  background-color: var(--ds-color-neutral-background-tinted);
+  border: var(--ds-border-width-default) solid var(--ds-color-neutral-background-tinted);
+  border-radius: var(--ds-border-radius-xl);
+  overflow: hidden;
+  text-decoration: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.cardLink.cardLink:hover,
+.cardLink.cardLink:focus-visible {
+  border-color: var(--ds-color-primary-color-red-border-subtle);
+  box-shadow: var(--ds-shadow-md);
+}
+
+/* Card anatomy per the concept listing cards: full-bleed media band on top,
+   left-aligned body with title, thin divider, "Les mer →" text-button. */
+.cardMedia {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  height: calc(var(--ds-size-30) * 0.9);
+  width: 100%;
+  background-color: var(--ds-color-primary-color-red-surface-tinted);
+}
+
+.cardIcon {
+  width: var(--ds-size-15);
+  height: var(--ds-size-15);
+  object-fit: contain;
+  opacity: 0.9;
+}
+
+.iconPlaceholder {
+  width: var(--ds-size-15);
+  height: var(--ds-size-15);
+  background-color: var(--ds-color-neutral-surface-tinted);
+  border-radius: var(--ds-border-radius-full);
+}
+
+.cardBody {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  text-align: left;
+  padding: var(--ds-size-5) var(--ds-size-6) var(--ds-size-5);
+}
+
+.cardTitle[class] {
+  color: var(--ds-color-primary-color-red-text-default);
+  font-weight: var(--ds-font-weight-semibold);
+  margin-bottom: var(--ds-size-4);
+}
+
+/* Thin rule above the action, like the concept cards */
+.cardDivider {
+  width: 100%;
+  border: none;
+  border-top: 1px solid var(--ds-color-neutral-border-subtle);
+  margin: 0 0 var(--ds-size-4);
+}
+
+/* Text-button language: maroon label + arrow, pink pill appears on hover/focus */
+.cardAction {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ds-size-2);
+  color: var(--ds-color-primary-color-red-text-default);
+  font-size: var(--ds-font-size-3);
+  font-weight: var(--ds-font-weight-medium);
+  padding: var(--ds-size-1) var(--ds-size-4);
+  margin-left: calc(-1 * var(--ds-size-4));
+  border-radius: var(--ds-border-radius-full);
+  transition: background-color 0.2s ease;
+}
+
+.cardArrow {
+  flex-shrink: 0;
+  transition: transform 0.2s ease;
+}
+
+.cardLink:hover .cardAction,
+.cardLink:focus-visible .cardAction {
+  background-color: var(--ds-color-primary-color-red-surface-hover);
+}
+
+.cardLink:hover .cardArrow {
+  transform: translateX(var(--ds-size-1));
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .cardLink.cardLink,
+  .cardAction,
+  .cardArrow,
+  .searchInput {
+    transition: none;
   }
 
+  .cardLink:hover .cardArrow {
+    transform: none;
+  }
+}
 
-  /* Card Internals */
-  .cardContent {
-    display: flex;
+/* Empty state: soft cream panel */
+.emptyState {
+  text-align: center;
+  padding: var(--ds-size-12);
+  color: var(--ds-color-neutral-text-subtle);
+  background-color: var(--ds-color-neutral-background-tinted);
+  border-radius: var(--ds-border-radius-xl);
+}
+
+/* Green CTA banner (design retning pattern): two columns, pale green, xl radius */
+.ctaBanner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--ds-size-8);
+  background-color: var(--ds-color-additional-color-jungle-surface-tinted);
+  border-radius: var(--ds-border-radius-xl);
+  padding: var(--ds-size-10) var(--ds-size-12);
+  margin-top: var(--ds-size-15);
+}
+
+.ctaBannerTitle[class] {
+  color: var(--ds-color-primary-color-red-text-default);
+  margin-bottom: var(--ds-size-3);
+}
+
+.ctaBannerBody {
+  color: var(--ds-color-neutral-text-default);
+  max-width: 55ch;
+}
+
+.ctaBannerButton[class] {
+  flex-shrink: 0;
+}
+
+@media (max-width: 768px) {
+  .ctaBanner {
     flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    padding: var(--ds-size-4) 0;
-    text-align: center;
+    align-items: flex-start;
+    padding: var(--ds-size-8) var(--ds-size-6);
   }
-  
-  .cardIconWrapper {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    margin-bottom: var(--ds-size-4);
-    /* Use token size for container height to ensure alignment */
-    height: var(--ds-size-14); 
-    width: 100%;
-  }
-  
-  .cardIcon {
-    /* Dynamic sizing based on tokens approx 3rem */
-    width: var(--ds-size-12);
-    height: var(--ds-size-12);
-    object-fit: contain;
-    /* Optional: filter to align icon color with text if SVGs are monochromatic */
-    opacity: 0.9;
-  }
-  
-  .iconPlaceholder {
-    width: var(--ds-size-12);
-    height: var(--ds-size-12);
-    background-color: var(--ds-color-neutral-surface-tinted);
-    border-radius: var(--ds-border-radius-full);
-  }
-  
-  /* Empty State */
-  .emptyState {
-    text-align: center;
-    padding: var(--ds-size-12);
-    color: var(--ds-color-neutral-text-subtle);
-  }
+}

--- a/src/pages/Design/index.tsx
+++ b/src/pages/Design/index.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { ArrowRightIcon } from '@navikt/aksel-icons';
 import { useLanguage } from '../../context/LanguageContext';
 import { Heading } from '../../components/Heading';
 import { Paragraph } from '../../components/Paragraph';
@@ -90,11 +91,11 @@ const FargerOversiktContent = () => {
       
       <ArticleImage src="/SemanticColorUsage.png" alt="Semantiske farger eksempel" caption={t('design.colorOverview.semanticCaption')} />
 
-      <table style={{ width: '100%', borderCollapse: 'collapse', marginBottom: 'var(--ds-size-8)' }}>
+      <table className={styles.tokenTable}>
         <thead>
-          <tr style={{ borderBottom: '2px solid var(--ds-color-neutral-border-default)', textAlign: 'left' }}>
-            <th style={{ padding: 'var(--ds-size-2)', fontWeight: 'bold' }}>{t('design.colorOverview.tableName')}</th>
-            <th style={{ padding: 'var(--ds-size-2)', fontWeight: 'bold' }}>{t('design.colorOverview.tableUsage')}</th>
+          <tr>
+            <th>{t('design.colorOverview.tableName')}</th>
+            <th>{t('design.colorOverview.tableUsage')}</th>
           </tr>
         </thead>
         <tbody>
@@ -116,9 +117,9 @@ const FargerOversiktContent = () => {
             ['base-contrast-subtle', t('design.colorOverview.baseContrastSubtle')],
             ['base-contrast-default', t('design.colorOverview.baseContrastDefault')],
           ].map(([name, desc]) => (
-            <tr key={name} style={{ borderBottom: '1px solid var(--ds-color-neutral-border-subtle)' }}>
-              <td style={{ padding: 'var(--ds-size-2)', fontFamily: 'monospace' }}>{name}</td>
-              <td style={{ padding: 'var(--ds-size-2)' }}>{desc}</td>
+            <tr key={name}>
+              <td><span className={styles.tokenName}>{name}</span></td>
+              <td>{desc}</td>
             </tr>
           ))}
         </tbody>
@@ -1139,16 +1140,22 @@ export const DesignPage = ({ section }: DesignPageProps) => {
   const DefaultDesignContent = () => (
     <ArticleLayout title={t('design.intro.title')} intro={t('design.intro.welcome')} category="Intro">
       <div className={styles.introGrid}>
-        <Card variant="tinted" data-color="neutral">
+        <Card variant="tinted" data-color="neutral" className={styles.introCard}>
           <CardBlock>
             <Heading level={3} data-size="sm">{t('design.intro.getStarted')}</Heading>
-            <Link href="#" onClick={(e) => {e.preventDefault(); setActiveDesignPage('figma-oppkobling')}}>{t('design.intro.goToGuide')}</Link>
+            <Link href="#" className={styles.textButton} onClick={(e) => {e.preventDefault(); setActiveDesignPage('figma-oppkobling')}}>
+              {t('design.intro.goToGuide')}
+              <ArrowRightIcon aria-hidden />
+            </Link>
           </CardBlock>
         </Card>
-        <Card variant="tinted" data-color="neutral">
+        <Card variant="tinted" data-color="neutral" className={styles.introCard}>
           <CardBlock>
             <Heading level={3} data-size="sm">{t('design.intro.colors')}</Heading>
-            <Link href="#" onClick={(e) => {e.preventDefault(); setActiveDesignPage('fargesystem')}}>{t('design.intro.seeColors')}</Link>
+            <Link href="#" className={styles.textButton} onClick={(e) => {e.preventDefault(); setActiveDesignPage('fargesystem')}}>
+              {t('design.intro.seeColors')}
+              <ArrowRightIcon aria-hidden />
+            </Link>
           </CardBlock>
         </Card>
       </div>

--- a/src/pages/Design/styles.module.css
+++ b/src/pages/Design/styles.module.css
@@ -6,6 +6,7 @@
   align-items: flex-start;
 }
 
+/* Sidebar as a soft cream panel (warm band against the white content) */
 .sidebar {
   width: 280px;
   flex-shrink: 0;
@@ -15,8 +16,10 @@
   max-height: calc(100vh - var(--ds-size-12));
   overflow-y: auto;
   overflow-x: hidden;
-  padding-right: var(--ds-size-4);
-  padding-top: var(--ds-size-10);
+  margin-top: var(--ds-size-10);
+  padding: var(--ds-size-6) var(--ds-size-4);
+  background: var(--ds-color-neutral-background-tinted);
+  border-radius: var(--ds-border-radius-xl);
 }
 
 /* Custom Scrollbar for Sidebar */
@@ -28,7 +31,7 @@
 }
 .sidebar::-webkit-scrollbar-thumb {
   background-color: var(--ds-color-neutral-border-subtle);
-  border-radius: 3px;
+  border-radius: var(--ds-border-radius-full);
 }
 
 .nav {
@@ -42,15 +45,15 @@
   flex-direction: column;
 }
 
+/* Group titles: maroon, semibold — page-level wayfinding */
 .groupTitle {
-  font-size: var(--ds-font-size-sm, 14px);
-  font-weight: var(--ds-font-weight-bold, 700);
-  color: var(--ds-color-neutral-text-subtle, #5d5d5d);
+  font-size: var(--ds-font-size-2);
+  font-weight: var(--ds-font-weight-semibold);
+  color: var(--ds-color-primary-color-red-text-default);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  margin-bottom: var(--ds-size-2, 8px);
-  padding-left: var(--ds-size-3, 12px);
-  border-left: 4px solid var(--ds-color-primary-color-red-base-default);
+  margin-bottom: var(--ds-size-2);
+  padding-left: var(--ds-size-3);
 }
 
 .list {
@@ -63,6 +66,7 @@
   margin-bottom: 2px;
 }
 
+/* Nav links: soft pills on the cream panel */
 .link {
   display: flex;
   align-items: center;
@@ -72,7 +76,7 @@
   font-size: var(--ds-font-size-md);
   color: var(--ds-color-neutral-text-default);
   text-decoration: none;
-  border-radius: var(--ds-border-radius-md);
+  border-radius: var(--ds-border-radius-full);
   transition: all 0.2s ease;
   background: transparent;
   border: none;
@@ -82,13 +86,13 @@
 }
 
 .link:hover {
-  background-color: var(--ds-color-neutral-surface-hover);
+  background-color: var(--ds-color-neutral-background-default);
   color: var(--ds-color-neutral-text-default);
 }
 
 .linkActive {
-  background-color: var(--ds-color-primary-surface-subtle);
-  color: var(--ds-color-primary-text-default);
+  background-color: var(--ds-color-primary-color-red-surface-tinted);
+  color: var(--ds-color-primary-color-red-text-default);
   font-weight: var(--ds-font-weight-medium);
 }
 
@@ -100,6 +104,7 @@
   display: none;
 }
 
+/* Nested list: dusty pink thread as the "rød tråd" accent */
 .nestedList {
   list-style: none;
   display: flex;
@@ -107,7 +112,7 @@
   gap: 1px;
   padding-left: var(--ds-size-3);
   margin-top: 2px;
-  border-left: 1px solid var(--ds-color-neutral-border-subtle);
+  border-left: 1px solid var(--ds-color-primary-color-red-border-subtle);
   margin-left: var(--ds-size-3);
 }
 
@@ -119,25 +124,127 @@
 
 .nestedLink:hover {
   color: var(--ds-color-neutral-text-default);
-  background-color: var(--ds-color-neutral-surface-hover);
+  background-color: var(--ds-color-neutral-background-default);
 }
 
 .nestedLinkActive {
-  color: var(--ds-color-primary-text-default);
-  background-color: var(--ds-color-primary-surface-subtle);
+  color: var(--ds-color-primary-color-red-text-default);
+  background-color: var(--ds-color-primary-color-red-surface-tinted);
   font-weight: var(--ds-font-weight-medium);
-  border-left: 2px solid var(--ds-color-primary-base-default);
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-  margin-left: -1px; /* Overlap border */
 }
 
 .docContent {
   flex: 1;
   padding-left: var(--ds-size-10);
-  border-left: 1px solid var(--ds-color-neutral-border-subtle);
   min-width: 0;
   padding-top: var(--ds-size-18);
+}
+
+/* --- Article typography (design direction: Skala) --- */
+
+/* Page-level titles: large, semibold, maroon */
+.docContent h1[class] {
+  color: var(--ds-color-primary-color-red-text-default);
+  font-size: var(--ds-font-size-9);
+  font-weight: var(--ds-font-weight-semibold);
+}
+
+/* Sub-heads stay neutral, semibold for hierarchy */
+.docContent h2[class],
+.docContent h3[class] {
+  color: var(--ds-color-neutral-text-default);
+  font-weight: var(--ds-font-weight-semibold);
+}
+
+/* Text links: maroon underlined, red on hover (Fargehierarki) */
+.docContent a[class]:not(.textButton) {
+  color: var(--ds-color-primary-color-red-text-default);
+  text-decoration: underline;
+}
+
+.docContent a[class]:not(.textButton):hover {
+  color: var(--ds-color-primary-color-red-text-subtle);
+}
+
+/* Text button: maroon text + arrow, pink pill on hover (Fargehierarki spec) */
+.docContent a.textButton {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ds-size-2);
+  align-self: flex-start;
+  color: var(--ds-color-primary-color-red-text-default);
+  font-weight: var(--ds-font-weight-medium);
+  text-decoration: none;
+  padding: var(--ds-size-2) var(--ds-size-4);
+  margin-left: calc(var(--ds-size-4) * -1);
+  border-radius: var(--ds-border-radius-full);
+  transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.docContent a.textButton:hover {
+  background-color: var(--ds-color-primary-color-red-surface-hover);
+  color: var(--ds-color-primary-color-red-text-default);
+}
+
+.textButton svg {
+  font-size: var(--ds-font-size-4);
+  transition: transform 0.2s ease;
+}
+
+.textButton:hover svg {
+  transform: translateX(var(--ds-size-1));
+}
+
+/* Figures: cream panels with soft radii instead of grey bordered boxes */
+.docContent :global(.article-image) {
+  background: var(--ds-color-neutral-background-tinted);
+  border-radius: var(--ds-border-radius-xl);
+  padding: var(--ds-size-5);
+}
+
+.docContent :global(.article-image) img {
+  display: block;
+  border-radius: var(--ds-border-radius-lg) !important;
+  border: none !important;
+}
+
+/* Token table: cream panel, soft radius, no hard grid */
+.tokenTable {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  background: var(--ds-color-neutral-background-tinted);
+  border-radius: var(--ds-border-radius-xl);
+  overflow: hidden;
+  margin-bottom: var(--ds-size-8);
+}
+
+.tokenTable th {
+  text-align: left;
+  padding: var(--ds-size-3) var(--ds-size-4);
+  font-weight: var(--ds-font-weight-semibold);
+  color: var(--ds-color-primary-color-red-text-default);
+  border-bottom: 1px solid var(--ds-color-primary-color-red-border-subtle);
+}
+
+.tokenTable td {
+  padding: var(--ds-size-3) var(--ds-size-4);
+  color: var(--ds-color-neutral-text-default);
+  border-bottom: 1px solid var(--ds-color-neutral-border-subtle);
+}
+
+.tokenTable tr:last-child td {
+  border-bottom: none;
+}
+
+.tokenName {
+  display: inline-block;
+  background: var(--ds-color-neutral-background-default);
+  border-radius: var(--ds-border-radius-full);
+  padding: var(--ds-size-1) var(--ds-size-3);
+  font-size: var(--ds-font-size-2);
+  font-weight: var(--ds-font-weight-medium);
+  color: var(--ds-color-neutral-text-default);
 }
 
 /* Sidebar toggle button — hidden on desktop */
@@ -145,9 +252,9 @@
   display: none;
   width: 100%;
   padding: var(--ds-size-3) var(--ds-size-4);
-  background: var(--ds-color-neutral-surface-tinted);
-  border: 1px solid var(--ds-color-neutral-border-subtle);
-  border-radius: var(--ds-border-radius-md);
+  background: var(--ds-color-neutral-background-tinted);
+  border: none;
+  border-radius: var(--ds-border-radius-full);
   font-family: inherit;
   font-size: var(--ds-font-size-md);
   font-weight: var(--ds-font-weight-medium);
@@ -172,6 +279,15 @@
   gap: var(--ds-size-6);
 }
 
+/* Intro cards: cream, extra-soft radius, no border */
+.docContent .introCard {
+  position: relative;
+  overflow: hidden;
+  border: none;
+  border-radius: var(--ds-border-radius-xl);
+  background: var(--ds-color-neutral-background-tinted);
+}
+
 @media (max-width: 768px) {
   .docLayout {
     flex-direction: column;
@@ -184,10 +300,8 @@
     position: static;
     max-height: none;
     overflow: visible;
-    border-bottom: 1px solid var(--ds-color-neutral-border-subtle);
-    padding-right: 0;
-    padding-top: var(--ds-size-4);
-    padding-bottom: var(--ds-size-4);
+    margin-top: var(--ds-size-4);
+    padding: var(--ds-size-4);
   }
 
   .sidebarCollapsed {
@@ -196,12 +310,12 @@
 
   .sidebarToggle {
     display: block;
+    margin-top: var(--ds-size-4);
   }
 
   .docContent {
     padding-left: 0;
     padding-top: var(--ds-size-6);
-    border-left: none;
   }
 
   .introGrid {

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -10,9 +10,7 @@ import { Chip } from '../../components/Chip';
 import { DesignAnimation } from '../../animations/DesignAnimation';
 import { CodeAnimation } from '../../animations/CodeAnimation';
 import {
-  WheelchairIcon,
   PaletteIcon,
-  LightningIcon,
   ComponentIcon,
   CodeIcon,
   ArrowRightIcon
@@ -29,177 +27,194 @@ export const HomePage = ({ setPage }: HomePageProps) => {
 
   return (
     <main className={styles.main}>
-      {/* --- HERO SECTION --- */}
+      {/* --- HERO: typography-led cream panel ("Millioner av sivile rammet" / tilbud-hero treatment) --- */}
       <section className={styles.heroSection}>
-        <div className={`container ${styles.splitLayout} ${styles.heroContainer}`}>
-          
-          {/* Content Side */}
-          <div className={styles.splitContent}>
-            <Tag data-color="neutral" data-size="sm" className={styles.versionBadge}>
-              v1.1 · Open Source
-            </Tag>
-            <Heading level={1} data-size="2xl" className={styles.heroTitle}>
-              {t('home.heroTitle')}
+        <div className="container">
+          <div className={styles.heroPanel}>
+            {/* Notch: white step cut out of the panel's top-left corner ("krysset" cutout).
+                Holds the release badge — the system's "stamp" in the brand-mark slot. */}
+            <div className={styles.heroNotch}>
+              <Tag data-color="main" data-size="sm">v1.2</Tag>
+              <span className={styles.notchMeta}>Open Source</span>
+            </div>
+            <span className={styles.heroKicker}>{t('home.hero.kicker')}</span>
+            <Heading level={1} className={styles.heroTitle}>
+              {t('home.hero.title')}
             </Heading>
-
             <Paragraph data-size="lg" className={styles.heroLead}>
-              {t('home.heroLead')}
+              {t('home.hero.lead')}
             </Paragraph>
-            
+
             <div className={styles.heroActions}>
-              <Button onClick={() => setPage('components')} data-size="lg">
-                {t('home.searchComponents')}
+              <Button onClick={() => setPage('code')} data-size="lg">
+                {t('home.hero.primaryCta')}
+                <ArrowRightIcon aria-hidden />
               </Button>
-              <Button 
-                variant="secondary" 
+              <Button
+                variant="secondary"
                 data-size="lg"
-                onClick={() => window.open('https://github.com/norwegianredcross/DesignSystem', '_blank')}
+                onClick={() => setPage('components')}
               >
-                GitHub
+                {t('home.hero.secondaryCta')}
               </Button>
             </div>
-          </div>
-          
-          {/* Visual Wall Side */}
-          <div className={styles.heroVisual}>
-            <div className={styles.floatingGrid}>
-              
-              {/* Column 1 */}
-              <div className={styles.gridColumn} style={{ animationDelay: '0s' }}>
-                 <Card variant="tinted" data-color="neutral" className={styles.visualCard}>
-                   <CardBlock>
-                     <Heading level={3} data-size="xs">{t('home.profile')}</Heading>
-                     <div className={styles.cardRow}>
-                       <Avatar aria-label="Avatar" initials="MH" />
-                       <div>
-                         <div className={styles.cardTextBold}>{t('home.name')}</div>
-                         <div className={styles.cardTextSubtle}>{t('home.volunteer')}</div>
-                       </div>
-                     </div>
-                   </CardBlock>
-                 </Card>
-                 <Card variant="default" className={styles.visualElement}>
-                   <Button variant="primary" style={{ width: '100%' }}>{t('home.save')}</Button>
-                 </Card>
-                 <Card variant="default" className={styles.visualElement}>
-                   <Tag data-color="success" data-size="sm">{t('home.approved')}</Tag>
-                   <Tag data-color="danger" data-size="sm">{t('home.rejected')}</Tag>
-                 </Card>
-              </div>
 
-              {/* Column 2 (Center Offset) */}
-              <div className={`${styles.gridColumn} ${styles.columnOffset}`} style={{ animationDelay: '1.5s' }}>
-                <Card variant="default" className={styles.visualElement}>
-                   <Switch label={t('home.darkModeLabel')} position="start" data-size="sm" />
-                 </Card>
-                 <Card variant="default" className={styles.visualCard} style={{ borderLeft: 'var(--ds-size-1) solid var(--ds-color-primary-color-red-base-default)' }}>
-                   <CardBlock>
-                     <Heading level={3} data-size="xs">{t('home.importantMessage')}</Heading>
-                     <Paragraph data-size="sm" style={{ marginTop: 'var(--ds-size-2)' }}>{t('home.updateGuidelines')}</Paragraph>
-                   </CardBlock>
-                 </Card>
-                 <Card variant="default" className={styles.visualElement}>
-                   <div className={styles.cardRow} style={{gap: 'var(--ds-size-2)'}}>
-                     <Chip.Radio name="filter-demo" value="all" defaultChecked>{t('home.all')}</Chip.Radio>
-                     <Chip.Radio name="filter-demo" value="active">{t('home.active')}</Chip.Radio>
-                   </div>
-                 </Card>
+            {/* Specimen shelf: real components from the library on a white plate.
+                Decorative — inert keeps them out of the tab order. */}
+            <div className={styles.heroSpecimen} aria-hidden="true" inert>
+              <Button data-size="sm">{t('home.hero.specimenButton')}</Button>
+              <Tag data-color="success" data-size="sm">{t('home.approved')}</Tag>
+              <Chip.Radio name="hero-specimen" value="all" defaultChecked>
+                {t('home.all')}
+              </Chip.Radio>
+              <Switch label={t('home.darkModeLabel')} position="start" data-size="sm" />
+              <Avatar aria-label="" initials="RK" data-size="sm" />
+              <Badge data-color="primary" count={5} maxCount={9} />
+              <div className={styles.specimenProgress}>
+                <div className={styles.progressBarBg}>
+                  <div className={styles.progressBarFill}></div>
+                </div>
               </div>
-
-               {/* Column 3 */}
-               <div className={styles.gridColumn} style={{ animationDelay: '0.8s' }}>
-                 <Card variant="default" className={styles.visualElement}>
-                   <Badge data-color="primary" count={5} maxCount={9} />
-                   <Button variant="tertiary">{t('home.alerts')}</Button>
-                 </Card>
-                 <Card variant="tinted" data-color="primary" className={styles.visualCard}>
-                   <CardBlock>
-                     <div className={styles.spaceBetween}>
-                       <Heading level={3} data-size="xs">{t('home.status')}</Heading>
-                       <div className={styles.statusDot}></div>
-                     </div>
-                     <div className={styles.progressBarBg}>
-                       <div className={styles.progressBarFill}></div>
-                     </div>
-                   </CardBlock>
-                 </Card>
-              </div>
-
             </div>
-            <div className={styles.gradientOverlay}></div>
           </div>
         </div>
       </section>
 
-      {/* --- BENTO NAVIGATION --- */}
+      {/* --- STATS ROW ("Skala") --- */}
+      <section className={styles.statsSection}>
+        <div className={`container ${styles.statsGrid}`}>
+          <Card variant="default" className={styles.statCard}>
+            <CardBlock className={styles.statBlock}>
+              <div className={styles.statNumber}>39</div>
+              <Paragraph data-size="sm" className={styles.statLabel}>
+                {t('header.nav.components')}
+              </Paragraph>
+            </CardBlock>
+          </Card>
+          <Card variant="default" className={styles.statCard}>
+            <CardBlock className={styles.statBlock}>
+              <div className={styles.statNumber}>WCAG 2.1</div>
+              <Paragraph data-size="sm" className={styles.statLabel}>
+                {t('home.universalDesign')}
+              </Paragraph>
+            </CardBlock>
+          </Card>
+          <Card variant="default" className={styles.statCard}>
+            <CardBlock className={styles.statBlock}>
+              <div className={styles.statNumber}>v1.2</div>
+              <Paragraph data-size="sm" className={styles.statLabel}>
+                Open Source
+              </Paragraph>
+            </CardBlock>
+          </Card>
+        </div>
+      </section>
+
+      {/* --- PALETTE STRIP ("Utvidet fargepalett") --- */}
+      <section className={styles.paletteSection}>
+        <div className="container">
+          <div className={styles.paletteHeader}>
+            <Heading level={2} className={styles.sectionTitle} data-size="lg">
+              {t('home.palette.title')}
+            </Heading>
+            <Paragraph data-size="lg" className={styles.paletteLead}>
+              {t('home.palette.lead')}
+            </Paragraph>
+          </div>
+          <div className={styles.paletteCircles} aria-hidden="true">
+            <span className={`${styles.paletteCircle} ${styles.swatchRed}`} />
+            <span className={`${styles.paletteCircle} ${styles.swatchMaroon}`} />
+            <span className={`${styles.paletteCircle} ${styles.swatchDustyPink}`} />
+            <span className={`${styles.paletteCircle} ${styles.swatchPalePink}`} />
+            <span className={`${styles.paletteCircle} ${styles.swatchWhite}`} />
+            <span className={`${styles.paletteCircle} ${styles.swatchCream}`} />
+            <span className={`${styles.paletteCircle} ${styles.swatchPaleGreen}`} />
+            <span className={`${styles.paletteCircle} ${styles.swatchGreen}`} />
+            <span className={`${styles.paletteCircle} ${styles.swatchPaleBlue}`} />
+          </div>
+          <button
+            type="button"
+            className={styles.paletteLink}
+            onClick={() => setPage('tokens')}
+          >
+            {t('home.palette.link')}
+            <ArrowRightIcon className={styles.arrowIcon} aria-hidden />
+          </button>
+        </div>
+      </section>
+
+      {/* --- NAVIGATION CARDS --- */}
       <section className={styles.section}>
         <div className="container">
-          <Heading level={2} className={styles.sectionTitle} data-size="xl">{t('home.exploreSystem')}</Heading>
-          
-          <div className={styles.bentoWrapper}>
+          <Heading level={2} className={styles.sectionTitle} data-size="lg">{t('home.exploreSystem')}</Heading>
+
+          <div className={styles.cardGrid}>
             {/* Components Card */}
             <Card
               variant="default"
-              className={styles.bentoItem}
+              className={styles.navCard}
               onClick={() => setPage('components')}
               role="button"
               tabIndex={0}
             >
-              <div className={styles.bentoContent}>
-                <div className={styles.bentoHeader}>
-                  <div className={styles.bentoIconBg}>
-                    <ComponentIcon className={styles.iconLarge} aria-hidden />
-                  </div>
+              <div className={styles.navCardContent}>
+                <div className={`${styles.navCardMedia} ${styles.mediaPink}`}>
+                  <ComponentIcon className={styles.iconLarge} aria-hidden />
+                </div>
+                <div className={styles.navCardText}>
+                  <Heading level={3} data-size="md" className={styles.navCardTitle}>{t('header.nav.components')}</Heading>
+                  <Paragraph className={styles.navCardDesc}>{t('home.componentsDesc')}</Paragraph>
+                </div>
+                <span className={styles.navCardLink}>
+                  {t('home.openComponents')}
                   <ArrowRightIcon className={styles.arrowIcon} aria-hidden />
-                </div>
-                <div className={styles.bentoText}>
-                  <Heading level={3} data-size="md">{t('header.nav.components')}</Heading>
-                  <Paragraph className={styles.bentoDesc}>{t('home.componentsDesc')}</Paragraph>
-                </div>
+                </span>
               </div>
             </Card>
 
             {/* Design Card */}
             <Card
               variant="default"
-              className={styles.bentoItem}
+              className={styles.navCard}
               onClick={() => setPage('design')}
               role="button"
               tabIndex={0}
             >
-              <div className={styles.bentoContent}>
-                <div className={styles.bentoHeader}>
-                  <div className={styles.bentoIconBg}>
-                    <PaletteIcon className={styles.iconLarge} aria-hidden />
-                  </div>
+              <div className={styles.navCardContent}>
+                <div className={`${styles.navCardMedia} ${styles.mediaGreen}`}>
+                  <PaletteIcon className={styles.iconLarge} aria-hidden />
+                </div>
+                <div className={styles.navCardText}>
+                  <Heading level={3} data-size="md" className={styles.navCardTitle}>{t('header.nav.design')}</Heading>
+                  <Paragraph className={styles.navCardDesc}>{t('home.designDesc')}</Paragraph>
+                </div>
+                <span className={styles.navCardLink}>
+                  {t('home.openDesign')}
                   <ArrowRightIcon className={styles.arrowIcon} aria-hidden />
-                </div>
-                <div className={styles.bentoText}>
-                  <Heading level={3} data-size="md">{t('header.nav.design')}</Heading>
-                  <Paragraph className={styles.bentoDesc}>{t('home.designDesc')}</Paragraph>
-                </div>
+                </span>
               </div>
             </Card>
 
             {/* Code Card */}
             <Card
               variant="default"
-              className={styles.bentoItem}
+              className={styles.navCard}
               onClick={() => setPage('code')}
               role="button"
               tabIndex={0}
             >
-              <div className={styles.bentoContent}>
-                <div className={styles.bentoHeader}>
-                  <div className={styles.bentoIconBg}>
-                    <CodeIcon className={styles.iconLarge} aria-hidden />
-                  </div>
+              <div className={styles.navCardContent}>
+                <div className={`${styles.navCardMedia} ${styles.mediaBlue}`}>
+                  <CodeIcon className={styles.iconLarge} aria-hidden />
+                </div>
+                <div className={styles.navCardText}>
+                  <Heading level={3} data-size="md" className={styles.navCardTitle}>{t('header.nav.code')}</Heading>
+                  <Paragraph className={styles.navCardDesc}>{t('home.codeDesc')}</Paragraph>
+                </div>
+                <span className={styles.navCardLink}>
+                  {t('home.openCode')}
                   <ArrowRightIcon className={styles.arrowIcon} aria-hidden />
-                </div>
-                <div className={styles.bentoText}>
-                  <Heading level={3} data-size="md">{t('header.nav.code')}</Heading>
-                  <Paragraph className={styles.bentoDesc}>{t('home.codeDesc')}</Paragraph>
-                </div>
+                </span>
               </div>
             </Card>
 
@@ -211,7 +226,7 @@ export const HomePage = ({ setPage }: HomePageProps) => {
       <section id="showcase" className={styles.showcaseSection}>
         <div className={`container ${styles.showcaseContainer}`}>
           <div className={styles.showcaseIntro}>
-            <Heading level={2} data-size="xl" className={styles.sectionTitle}>
+            <Heading level={2} data-size="lg" className={styles.sectionTitle}>
               {t('home.showcase.title')}
             </Heading>
             <Paragraph data-size="lg" className={styles.showcaseLead}>
@@ -274,66 +289,26 @@ export const HomePage = ({ setPage }: HomePageProps) => {
         </div>
       </section>
 
-      {/* --- VALUES SECTION --- */}
-      <section className={styles.sectionValues} data-color-scheme="dark">
+      {/* --- CONTRIBUTION CTA BANNER (green, replaces the values section) --- */}
+      <section className={styles.ctaSection}>
         <div className="container">
-          <div className={styles.valuesGrid}>
-            <div className={styles.valueItem}>
-              <div className={styles.valueIcon}>
-                <WheelchairIcon className={styles.iconXLarge} aria-hidden />
-              </div>
-              <Heading level={3} data-size="sm" className={styles.valueTitle}>{t('home.universalDesign')}</Heading>
-              <Paragraph data-size="sm" className={styles.valueText}>
-                {t('home.universalDesignText')}
+          <div className={styles.ctaBanner}>
+            <div className={styles.ctaText}>
+              <Heading level={2} data-size="lg" className={styles.ctaTitle}>
+                Vil du bidra til designsystemet?
+              </Heading>
+              <Paragraph className={styles.ctaBody}>
+                Designsystemet er åpen kildekode. Rapporter feil, foreslå forbedringer
+                eller bidra med kode og dokumentasjon på GitHub.
               </Paragraph>
-              <Button
-                variant="tertiary"
-                data-color="primary"
-                data-size="sm"
-                onClick={() => setPage('design')}
-                className={styles.valueButton}
-              >
-                {t('home.readGuidelines')}
-                <ArrowRightIcon aria-hidden />
-              </Button>
             </div>
-
-            <div className={styles.valueItem}>
-              <div className={styles.valueIcon}>
-                <PaletteIcon className={styles.iconXLarge} aria-hidden />
-              </div>
-              <Heading level={3} data-size="sm" className={styles.valueTitle}>{t('home.consistentBrand')}</Heading>
-              <Paragraph data-size="sm" className={styles.valueText}>
-                {t('home.consistentBrandText')}
-              </Paragraph>
+            <div className={styles.ctaAction}>
               <Button
-                variant="tertiary"
-                data-color="primary"
-                data-size="sm"
-                onClick={() => setPage('design')}
-                className={styles.valueButton}
+                variant="secondary"
+                data-size="lg"
+                onClick={() => window.open('https://github.com/norwegianredcross/DesignSystem', '_blank')}
               >
-                {t('home.seeColors')}
-                <ArrowRightIcon aria-hidden />
-              </Button>
-            </div>
-
-            <div className={styles.valueItem}>
-              <div className={styles.valueIcon}>
-                <LightningIcon className={styles.iconXLarge} aria-hidden />
-              </div>
-              <Heading level={3} data-size="sm" className={styles.valueTitle}>{t('home.efficientDev')}</Heading>
-              <Paragraph data-size="sm" className={styles.valueText}>
-                {t('home.efficientDevText')}
-              </Paragraph>
-              <Button
-                variant="tertiary"
-                data-color="primary"
-                data-size="sm"
-                onClick={() => setPage('components')}
-                className={styles.valueButton}
-              >
-                {t('home.exploreComponents')}
+                GitHub
                 <ArrowRightIcon aria-hidden />
               </Button>
             </div>

--- a/src/pages/Home/styles.module.css
+++ b/src/pages/Home/styles.module.css
@@ -1,464 +1,585 @@
-/* Main Layout */
+/* Main Layout — white page canvas; sections use inset panels (concept-page rhythm) */
 .main {
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-    overflow-x: hidden;
-    background-color: var(--ds-color-neutral-background-default);
-  }
-  
-  /* --- HERO SECTION --- */
-  .heroSection {
-    position: relative;
-    /* Using tokens for vertical padding */
-    padding: calc(var(--ds-size-30) + var(--ds-size-10)) 0 var(--ds-size-30);
-    background-color: var(--ds-color-neutral-background-default);
-    overflow: hidden; /* Ensure the large floating grid doesn't cause scrollbars */
-  }
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow-x: hidden;
+  background-color: var(--ds-color-neutral-background-default);
+}
 
-  .heroSection::after {
-    content: '';
-    position: absolute;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-    height: var(--ds-size-26);
-    background: linear-gradient(to bottom, transparent, var(--ds-color-neutral-background-default));
-    pointer-events: none;
-  }
-  
-  .splitLayout {
-    display: flex;
-    flex-direction: column;
-    gap: var(--ds-size-12);
-  }
-  
-  /* Content Side */
-  .splitContent {
-    position: relative;
-    z-index: 10;
-    max-width: 100%;
-  }
-  
-  .heroBadge {
-    display: inline-block;
-    padding: var(--ds-size-1) var(--ds-size-3);
-    background-color: var(--ds-color-primary-color-red-surface-tinted);
-    color: var(--ds-color-primary-color-red-text-default);
-    font-size: var(--ds-font-size-2);
-    font-weight: var(--ds-font-weight-bold);
-    border-radius: var(--ds-border-radius-full);
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    margin-bottom: var(--ds-size-6);
-    border: var(--ds-border-width-default) solid var(--ds-color-primary-color-red-border-subtle);
-  }
+/* --- HERO: inset rounded cream panel ("Varme" + "Avrunding") --- */
+.heroSection {
+  padding: var(--ds-size-8) 0 var(--ds-size-4);
+  background-color: var(--ds-color-neutral-background-default);
+}
 
-  .versionBadge {
-    margin-bottom: var(--ds-size-4);
-  }
+/* Panel with the "krysset" corner cutout. Geometry lifted from the Figma
+   boolean subtract (node 2277:118305): uniform 20px radius on every corner
+   (= --ds-border-radius-lg), notch ≈ 18.5% of width × 17% of height. */
+.heroPanel {
+  position: relative;
+  background-color: var(--ds-color-neutral-background-tinted);
+  border-radius: var(--ds-border-radius-lg);
+  border-top-left-radius: 0; /* corner is cut away by the notch */
+  padding: calc(var(--ds-size-26) + var(--ds-size-10)) var(--ds-size-8) var(--ds-size-12);
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  overflow: hidden;
+}
 
-  /* Hero title uses Heading data-size="2xl" natively. The extra weight,
-     tight letter-spacing and line-height below are a LIBRARY GAP — a
-     "display" heading variant for hero/brand contexts would cover this. */
-  .heroTitle {
-    margin-bottom: var(--ds-size-6);
-    font-weight: 800;
-    letter-spacing: -0.02em;
-    line-height: 1.1;
-  }
+/* Notch: a substantial step cut out of the panel's top-left corner.
+   Page-background token keeps the "cutout" illusion in dark mode. */
+.heroNotch {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: var(--ds-size-26);
+  min-width: calc(var(--ds-size-30) * 2);
+  background-color: var(--ds-color-neutral-background-default);
+  border-bottom-right-radius: var(--ds-border-radius-lg);
+  padding-left: var(--ds-size-8);
+  padding-right: var(--ds-size-15);
+  display: flex;
+  align-items: center;
+  gap: var(--ds-size-3);
+}
 
-  .textHighlight {
-    color: var(--ds-color-primary-color-red-base-default);
-    position: relative;
-    display: inline-block;
-  }
+.notchMeta {
+  font-size: var(--ds-font-size-2);
+  font-weight: var(--ds-font-weight-medium);
+  color: var(--ds-color-neutral-text-subtle);
+}
 
-  /* Hero lead: sizing from Paragraph data-size="lg". The subtle color is a
-     LIBRARY GAP — Paragraph doesn't have a `subtle` variant. */
-  .heroLead {
-    color: var(--ds-color-neutral-text-subtle);
-    max-width: 50ch;
-    margin-bottom: var(--ds-size-10);
-  }
-  
-  .heroActions {
-    display: flex;
-    flex-wrap: wrap;
-    gap: var(--ds-size-4);
-    margin-bottom: var(--ds-size-4);
-  }
-  
-  /* --- VISUAL WALL (Right Side) --- */
-  .heroVisual {
-    position: relative;
-    /* Using size tokens for height constraints */
-    height: calc(var(--ds-size-30) * 3.5);
-    width: 100%;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    perspective: 2000px; 
-    mask-image: linear-gradient(to bottom, transparent, black 10%, black 90%, transparent);
-  }
+/* Inverted fillets: concave 20px transitions where the step meets the
+   panel's top and left edges (same radius as every other corner). */
+.heroNotch::before,
+.heroNotch::after {
+  content: '';
+  position: absolute;
+  width: var(--ds-border-radius-lg);
+  height: var(--ds-border-radius-lg);
+  background: radial-gradient(
+    circle at 100% 100%,
+    transparent calc(var(--ds-border-radius-lg) - 1px),
+    var(--ds-color-neutral-background-default) var(--ds-border-radius-lg)
+  );
+}
 
-  .floatingGrid {
-    display: flex;
-    gap: var(--ds-size-2);
-    transform: rotateX(12deg) rotateY(-12deg) rotateZ(6deg) translateX(var(--ds-size-5));
-    transform-style: preserve-3d;
-  }
-  
-  .gridColumn {
-    display: flex;
-    flex-direction: column;
-    gap: var(--ds-size-5);
-    width: 200px; /* Fixed width for stability */
-    /* animation: floatColumn 14s ease-in-out infinite alternate; */
-  }
-  
-  .columnOffset {
-    margin-top: calc(var(--ds-size-22) * -1);
-  }
-  
-  @keyframes floatColumn {
-    0% { transform: translateY(0); }
-    100% { transform: translateY(calc(var(--ds-size-8) * -1)); }
-  }
-  
-  /* Decorative floating tiles: layout-only. Visuals come from ds-card + data-variant.
-     LIBRARY GAP: ds-card only ships one padding size (size-6). These decorative
-     tiles ideally need a compact-padding variant — until that exists, .visualElement
-     keeps a padding override. */
-  .visualCard, .visualElement {
-    transition: transform 0.3s ease;
-  }
+/* Fillet on the panel's top edge, right of the step */
+.heroNotch::before {
+  top: 0;
+  right: calc(-1 * var(--ds-border-radius-lg));
+}
 
-  .visualElement {
-    padding: var(--ds-size-3);
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: var(--ds-size-2);
-  }
-  
-  .cardRow { display: flex; gap: var(--ds-size-3); margin-top: var(--ds-size-3); align-items: center; }
-  .cardTextBold { font-weight: var(--ds-font-weight-bold); font-size: var(--ds-font-size-2); }
-  .cardTextSubtle { font-size: var(--ds-font-size-1); color: var(--ds-color-neutral-text-subtle); }
-  .spaceBetween { display: flex; justify-content: space-between; align-items: center; margin-bottom: var(--ds-size-2); }
-  .statusDot { width: var(--ds-size-2); height: var(--ds-size-2); border-radius: 50%; background-color: var(--ds-color-success-base-default); }
-  .progressBarBg { height: var(--ds-size-1); background-color: var(--ds-color-neutral-surface-active); border-radius: var(--ds-border-radius-full); width: 100%; overflow: hidden;}
-  .progressBarFill { height: 100%; width: 75%; background-color: var(--ds-color-primary-color-red-base-default); border-radius: var(--ds-border-radius-full); }
-  
-  .gradientOverlay {
-    position: absolute;
-    inset: 0;
-    background: radial-gradient(circle at 60% 50%, transparent 0%, var(--ds-color-neutral-background-default) 80%);
-    pointer-events: none;
-    z-index: 5;
-  }
-  
-  /* --- INTERACTIVE SHOWCASE --- */
-  .showcaseSection {
-    padding: var(--ds-size-30) 0 var(--ds-size-22);
-    background: var(--ds-color-neutral-background-default);
-  }
+/* Fillet on the panel's left edge, below the step */
+.heroNotch::after {
+  left: 0;
+  bottom: calc(-1 * var(--ds-border-radius-lg));
+}
 
-  .showcaseContainer {
-    display: flex;
-    flex-direction: column;
-    gap: var(--ds-size-10);
-  }
+/* Audience kicker — small uppercase red eyebrow */
+.heroKicker {
+  font-size: var(--ds-font-size-1);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: var(--ds-font-weight-semibold);
+  color: var(--ds-color-primary-color-red-text-subtle);
+  margin-bottom: var(--ds-size-5);
+}
 
-  .showcaseIntro {
-    max-width: 720px;
-    text-align: center;
-    margin: 0 auto;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    gap: var(--ds-size-4);
-  }
+/* Display statement heading ("Millioner av sivile rammet" treatment, Source Sans 3).
+   LIBRARY GAP: a display heading variant would cover this natively.
+   Doubled class out-ranks .ds-heading[data-size] from the library sheet. */
+.heroTitle.heroTitle {
+  margin-bottom: var(--ds-size-6);
+  max-width: 18ch;
+  font-size: var(--ds-font-size-9);
+  font-weight: var(--ds-font-weight-semibold);
+  letter-spacing: -0.02em;
+  line-height: 1.05;
+  color: var(--ds-color-primary-color-red-text-default);
+}
 
-  .showcaseIntro .sectionTitle {
-    margin-bottom: 0;
-  }
+/* Hero ingress. LIBRARY GAP: Paragraph has no `subtle` variant. */
+.heroLead {
+  color: var(--ds-color-neutral-text-default);
+  max-width: 55ch;
+  margin-bottom: var(--ds-size-10);
+}
 
-  .showcaseLead {
-    color: var(--ds-color-neutral-text-subtle);
-    margin: 0;
-  }
+.heroActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ds-size-4);
+  margin-bottom: var(--ds-size-12);
+}
 
-  .showcaseRows {
-    display: flex;
-    flex-direction: column;
-    gap: var(--ds-size-16);
-  }
+/* Specimen shelf — real components resting on a white plate inside the cream panel */
+.heroSpecimen {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--ds-size-6);
+  align-self: stretch;
+  max-width: 100%;
+  box-sizing: border-box;
+  background-color: var(--ds-color-neutral-background-default);
+  border-radius: var(--ds-border-radius-lg);
+  padding: var(--ds-size-5) var(--ds-size-8);
+}
 
-  .showcaseRow {
-    display: grid;
-    grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
-    gap: var(--ds-size-12);
-    align-items: center;
-  }
+.specimenProgress {
+  flex: 1;
+  min-width: var(--ds-size-22);
+  max-width: var(--ds-size-30);
+}
 
-  /* Row 2 flips so the copy sits on the left of the animation */
+.progressBarBg { height: var(--ds-size-1); background-color: var(--ds-color-neutral-surface-active); border-radius: var(--ds-border-radius-full); width: 100%; overflow: hidden;}
+.progressBarFill { height: 100%; width: 75%; background-color: var(--ds-color-primary-color-red-base-default); border-radius: var(--ds-border-radius-full); }
+
+/* --- STATS ROW ("Skala") — full-bleed pale-blue band per the "Stor typografi" slide --- */
+.statsSection {
+  padding: var(--ds-size-15) 0;
+  margin-top: var(--ds-size-10);
+  background-color: var(--ds-color-additional-color-ocean-background-tinted);
+}
+
+.statsGrid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--ds-size-6);
+}
+
+/* White cards on the blue band (reference: stat cards in "Stor typografi").
+   Doubled class out-ranks ds-card's [data-variant] background rule. */
+.statCard.statCard {
+  background: var(--ds-color-neutral-background-default);
+  border: none;
+  border-radius: var(--ds-border-radius-xl);
+}
+
+.statBlock.statBlock {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-size-3);
+  padding: var(--ds-size-8);
+}
+
+/* Big red display numbers — "Skala" */
+.statNumber {
+  font-size: var(--ds-font-size-8);
+  font-weight: var(--ds-font-weight-semibold);
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  color: var(--ds-color-primary-color-red-text-subtle);
+}
+
+.statLabel {
+  margin: 0;
+  color: var(--ds-color-neutral-text-subtle);
+}
+
+/* --- SECTION HEADING ROWS (concept-page pattern: heading directly above grid) --- */
+/* LIBRARY GAP: Heading has no color prop; maroon section headings aren't expressible natively. */
+.sectionTitle {
+  margin-bottom: var(--ds-size-8);
+  text-align: left;
+  color: var(--ds-color-primary-color-red-text-default);
+  font-weight: var(--ds-font-weight-semibold);
+}
+
+/* --- PALETTE STRIP ("Utvidet fargepalett" slide) --- */
+.paletteSection {
+  padding: var(--ds-size-15) 0 var(--ds-size-12);
+  background: var(--ds-color-neutral-background-default);
+}
+
+.paletteHeader {
+  max-width: 60ch;
+}
+
+/* LIBRARY GAP: Paragraph has no `subtle` variant. */
+.paletteLead {
+  color: var(--ds-color-neutral-text-subtle);
+  margin-top: calc(-1 * var(--ds-size-4));
+  margin-bottom: var(--ds-size-10);
+}
+
+.paletteCircles {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--ds-size-6);
+  margin-bottom: var(--ds-size-8);
+}
+
+/* Big soft circles; the inset ring keeps white/cream swatches readable
+   and flips automatically in dark mode via the token */
+.paletteCircle {
+  width: var(--ds-size-22);
+  height: var(--ds-size-22);
+  border-radius: var(--ds-border-radius-full);
+  box-shadow: inset 0 0 0 1px var(--ds-color-neutral-border-subtle);
+  flex-shrink: 0;
+}
+
+.swatchRed { background-color: var(--ds-color-primary-color-red-base-default); }
+.swatchMaroon { background-color: var(--ds-color-secondary-color-rust-text-default); }
+.swatchDustyPink { background-color: var(--ds-color-primary-color-red-border-subtle); }
+.swatchPalePink { background-color: var(--ds-color-primary-color-red-surface-tinted); }
+.swatchWhite { background-color: var(--ds-color-neutral-background-default); }
+.swatchCream { background-color: var(--ds-color-neutral-background-tinted); }
+.swatchPaleGreen { background-color: var(--ds-color-additional-color-jungle-surface-tinted); }
+.swatchGreen { background-color: var(--ds-color-additional-color-jungle-surface-hover); }
+.swatchPaleBlue { background-color: var(--ds-color-additional-color-ocean-background-tinted); }
+
+/* Text-button to the Tokens page (Fargehierarki pattern) */
+.paletteLink {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ds-size-2);
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-family: inherit;
+  font-size: var(--ds-font-size-4);
+  font-weight: var(--ds-font-weight-medium);
+  color: var(--ds-color-primary-color-red-text-default);
+  padding: var(--ds-size-2) var(--ds-size-5);
+  margin-left: calc(-1 * var(--ds-size-5));
+  border-radius: var(--ds-border-radius-full);
+  transition: background-color 0.2s ease;
+}
+
+.paletteLink:hover,
+.paletteLink:focus-visible {
+  background-color: var(--ds-color-primary-color-red-surface-hover);
+}
+
+/* --- NAVIGATION CARDS --- */
+.section {
+  padding: var(--ds-size-15) 0 var(--ds-size-10);
+  background: var(--ds-color-neutral-background-default);
+}
+
+.cardGrid {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--ds-size-6);
+}
+
+/* Card pattern: media/icon area on top, cream body, maroon title, text-button footer.
+   Doubled/tripled class selectors intentionally out-rank the ds-card
+   [data-variant] and :hover rules from the library stylesheet. */
+.navCard {
+  display: flex;
+  flex-direction: column;
+  border: none;
+  border-radius: var(--ds-border-radius-xl);
+}
+
+.navCard.navCard.navCard {
+  background: var(--ds-color-neutral-background-tinted);
+}
+
+/* Keep the cream surface on hover — the pink pill on the text-button is
+   the hover affordance (Fargehierarki), not a full-card colour shift. */
+.navCard.navCard.navCard:hover,
+.navCard.navCard.navCard:hover:active {
+  background: var(--ds-color-neutral-background-tinted);
+}
+
+.navCardContent {
+  position: relative;
+  z-index: 2;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Media area on top — icon on a tinted tile; tile colors rotate through
+   the extended palette (pink / green / blue) for visual variety */
+.navCardMedia {
+  height: calc(var(--ds-size-30) * 0.8);
+  border-radius: var(--ds-border-radius-lg);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--ds-color-primary-color-red-text-default);
+  margin-bottom: var(--ds-size-6);
+}
+
+.mediaPink { background-color: var(--ds-color-primary-color-red-surface-tinted); }
+.mediaGreen { background-color: var(--ds-color-additional-color-jungle-surface-tinted); }
+.mediaBlue { background-color: var(--ds-color-additional-color-ocean-background-tinted); }
+
+.iconLarge { font-size: var(--ds-font-size-9); }
+
+/* LIBRARY GAP: Heading has no color prop; maroon card titles need an override. */
+.navCardTitle {
+  color: var(--ds-color-primary-color-red-text-default);
+}
+
+/* LIBRARY GAP: Paragraph has no `subtle` variant. */
+.navCardDesc {
+  color: var(--ds-color-neutral-text-subtle);
+  margin-top: var(--ds-size-2);
+}
+
+.navCardText {
+  flex: 1;
+  margin-bottom: var(--ds-size-6);
+}
+
+.arrowIcon {
+  font-size: var(--ds-font-size-5);
+  color: currentColor;
+  transition: transform 0.3s ease, color 0.3s ease;
+}
+
+/* "Les mer →" text-button (maroon text + arrow) — gains the dusty-pink pill
+   on hover, per the Fargehierarki spec. Whole card is the interactive element. */
+.navCardLink {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ds-size-2);
+  align-self: flex-start;
+  margin-top: auto;
+  margin-left: calc(var(--ds-size-4) * -1);
+  padding: var(--ds-size-2) var(--ds-size-4);
+  border-radius: var(--ds-border-radius-full);
+  color: var(--ds-color-primary-color-red-text-default);
+  font-weight: var(--ds-font-weight-medium);
+  transition: background-color 0.2s ease;
+}
+
+.navCard:hover .navCardLink,
+.navCard:focus-visible .navCardLink {
+  background-color: var(--ds-color-primary-color-red-surface-hover);
+}
+
+.navCard:hover .arrowIcon {
+  transform: translateX(var(--ds-size-1));
+}
+
+/* --- INTERACTIVE SHOWCASE — white section with a left-aligned heading row --- */
+.showcaseSection {
+  padding: var(--ds-size-15) 0;
+  background: var(--ds-color-neutral-background-default);
+}
+
+.showcaseContainer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-size-10);
+}
+
+.showcaseIntro {
+  max-width: 720px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-size-2);
+}
+
+.showcaseIntro .sectionTitle {
+  margin-bottom: 0;
+}
+
+/* LIBRARY GAP: Paragraph has no `subtle` variant. */
+.showcaseLead {
+  color: var(--ds-color-neutral-text-subtle);
+  margin: 0;
+}
+
+.showcaseRows {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-size-16);
+}
+
+.showcaseRow {
+  display: grid;
+  grid-template-columns: minmax(0, 1.6fr) minmax(0, 1fr);
+  gap: var(--ds-size-12);
+  align-items: center;
+}
+
+/* Row 2 flips so the copy sits on the left of the animation */
+.showcaseRowRight {
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.6fr);
+}
+
+.showcaseAnimation {
+  min-width: 0;
+}
+
+.showcaseCopy {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-size-3);
+  max-width: 42ch;
+}
+
+.showcaseKicker {
+  font-size: var(--ds-font-size-1);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--ds-color-primary-color-red-text-default);
+  font-weight: var(--ds-font-weight-semibold);
+}
+
+.showcaseCopyTitle {
+  margin: 0;
+}
+
+/* LIBRARY GAP: Paragraph has no `subtle` variant. */
+.showcaseCopyBody {
+  margin: 0;
+  color: var(--ds-color-neutral-text-subtle);
+}
+
+@media (max-width: 900px) {
+  .showcaseRow,
   .showcaseRowRight {
-    grid-template-columns: minmax(0, 1fr) minmax(0, 1.6fr);
-  }
-
-  .showcaseAnimation {
-    min-width: 0;
-  }
-
-  .showcaseCopy {
-    display: flex;
-    flex-direction: column;
-    gap: var(--ds-size-3);
-    max-width: 42ch;
-  }
-
-  .showcaseKicker {
-    font-size: var(--ds-body-xs-font-size, 12px);
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
-    color: var(--ds-color-primary-color-red-text-default);
-    font-weight: var(--ds-font-weight-bold);
-  }
-
-  .showcaseCopyTitle {
-    margin: 0;
-  }
-
-  /* LIBRARY GAP: Paragraph has no `subtle` variant. */
-  .showcaseCopyBody {
-    margin: 0;
-    color: var(--ds-color-neutral-text-subtle);
-  }
-
-  @media (max-width: 900px) {
-    .showcaseRow,
-    .showcaseRowRight {
-      grid-template-columns: 1fr;
-      gap: var(--ds-size-6);
-    }
-
-    /* On stacked layout keep the animation above the copy regardless of row direction */
-    .showcaseRowRight .showcaseAnimation {
-      order: -1;
-    }
-
-    .showcaseCopy {
-      max-width: 100%;
-    }
-  }
-
-  /* --- BENTO NAVIGATION --- */
-  .section {
-    padding: var(--ds-size-22) 0;
-    background: var(--ds-color-neutral-background-tinted);
-  }
-  
-  .sectionTitle {
-    margin-bottom: var(--ds-size-12);
-    text-align: center;
-  }
-  
-  /* Bento Wrapper: The flex/grid container */
-  .bentoWrapper {
-    display: grid;
     grid-template-columns: 1fr;
     gap: var(--ds-size-6);
   }
-  
-  /* Bento Item: layout-only. Visuals come from ds-card + data-variant. */
-  .bentoItem {
-    display: flex;
-    flex-direction: column;
+
+  /* On stacked layout keep the animation above the copy regardless of row direction */
+  .showcaseRowRight .showcaseAnimation {
+    order: -1;
   }
 
-  /* Bento Content */
-  .bentoContent {
-    position: relative;
-    z-index: 2;
+  .showcaseCopy {
+    max-width: 100%;
+  }
+}
+
+/* --- CONTRIBUTION CTA BANNER — pale green inset panel ("Mennesker i fokus") --- */
+.ctaSection {
+  padding: var(--ds-size-8) 0 var(--ds-size-18);
+  background: var(--ds-color-neutral-background-default);
+}
+
+.ctaBanner {
+  background-color: var(--ds-color-additional-color-jungle-surface-tinted);
+  border-radius: var(--ds-border-radius-xl);
+  padding: var(--ds-size-12) var(--ds-size-8);
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-size-8);
+}
+
+.ctaText {
+  max-width: 56ch;
+}
+
+/* LIBRARY GAP: Heading has no color prop; maroon banner title needs an override. */
+.ctaTitle {
+  color: var(--ds-color-primary-color-red-text-default);
+  margin-bottom: var(--ds-size-4);
+}
+
+.ctaBody {
+  margin: 0;
+  color: var(--ds-color-neutral-text-default);
+}
+
+.ctaAction {
+  display: flex;
+  align-items: center;
+}
+
+/* --- RESPONSIVE MEDIA QUERIES --- */
+
+/* Tablet & Up */
+@media (min-width: 768px) {
+  .heroPanel {
+    padding: calc(var(--ds-size-26) + var(--ds-size-10)) var(--ds-size-12) var(--ds-size-15);
+  }
+
+  .heroTitle.heroTitle {
+    font-size: var(--ds-font-size-10);
+  }
+
+  .heroSpecimen {
+    gap: var(--ds-size-8);
+    padding: var(--ds-size-6) var(--ds-size-10);
+  }
+
+  .statsGrid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .statNumber {
+    font-size: var(--ds-font-size-10);
+  }
+
+  .cardGrid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .navCard {
     height: 100%;
-    display: flex;
-    flex-direction: column;
+    min-height: var(--ds-size-30);
   }
-  
-  .bentoHeader {
-    display: flex;
+
+  .ctaBanner {
+    flex-direction: row;
+    align-items: center;
     justify-content: space-between;
-    align-items: flex-start;
-    margin-bottom: var(--ds-size-6);
+    padding: var(--ds-size-15) var(--ds-size-12);
   }
-  
-  .bentoIconBg {
-    width: var(--ds-size-12);
-    height: var(--ds-size-12);
-    background-color: var(--ds-color-neutral-surface-tinted);
-    border-radius: var(--ds-border-radius-lg);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    color: var(--ds-color-neutral-text-default);
-  }
-  
-  .iconLarge { font-size: var(--ds-font-size-6); }
-  .iconXLarge { font-size: var(--ds-font-size-8); }
-  
-  /* LIBRARY GAP: Paragraph has no `subtle` variant. */
-  .bentoDesc {
-    color: var(--ds-color-neutral-text-subtle);
-    margin-top: var(--ds-size-2);
-  }
-  
-  .arrowIcon {
-    font-size: var(--ds-font-size-5);
-    color: var(--ds-color-neutral-text-subtle);
-    transition: transform 0.3s ease, color 0.3s ease;
+}
+
+/* Desktop & Up */
+@media (min-width: 1024px) {
+  .heroPanel {
+    padding: calc(var(--ds-size-26) + var(--ds-size-12)) var(--ds-size-15) var(--ds-size-15);
   }
 
-  .bentoItem:hover .arrowIcon {
-    transform: translate(var(--ds-size-1), calc(var(--ds-size-1) * -1));
+  .cardGrid {
+    gap: var(--ds-size-8);
+  }
+}
+
+/* Large Desktop & Up — full display scale for the statement heading */
+@media (min-width: 1200px) {
+  .heroTitle.heroTitle {
+    font-size: calc(var(--ds-font-size-10) * 1.2);
+  }
+}
+
+@media (max-width: 480px) {
+  .heroSection {
+    padding: var(--ds-size-4) 0;
   }
 
-
-  /* --- VALUES SECTION --- */
-  .sectionValues {
-    /* Dark red tinted background - forced dark mode via data-color-scheme="dark" on element */
-    background-color: var(--ds-color-primary-color-red-background-tinted);
-    padding: var(--ds-size-26) 0;
-    margin-top: var(--ds-size-12);
-    border-radius: var(--ds-border-radius-xl) var(--ds-border-radius-xl) 0 0;
+  .heroPanel {
+    padding: calc(var(--ds-size-18) + var(--ds-size-8)) var(--ds-size-6) var(--ds-size-10);
   }
 
-  .valuesGrid {
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: var(--ds-size-12);
+  .heroNotch {
+    height: var(--ds-size-18);
+    min-width: 0;
+    padding-left: var(--ds-size-4);
+    padding-right: var(--ds-size-8);
   }
 
-  /* Value Item: layout-only. Visuals come from ds-card + data-variant. */
-  .valueItem {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
+  .heroSpecimen {
+    gap: var(--ds-size-4);
+    padding: var(--ds-size-4) var(--ds-size-5);
   }
 
-  .valueIcon {
-    width: var(--ds-size-15);
-    height: var(--ds-size-15);
-    background-color: var(--ds-color-primary-color-red-surface-active);
-    border-radius: var(--ds-border-radius-lg);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    margin-bottom: var(--ds-size-6);
-    color: var(--ds-color-primary-color-red-text-default);
+  .statsSection {
+    padding: var(--ds-size-8) 0 var(--ds-size-4);
   }
 
-  /* LIBRARY GAP: Heading has no color prop; primary/accent heading color isn't expressible natively. */
-  .valueTitle {
-    color: var(--ds-color-primary-color-red-text-default);
-    margin-bottom: var(--ds-size-3);
+  .ctaSection {
+    padding: var(--ds-size-6) 0 var(--ds-size-12);
   }
 
-  .valueText {
-    margin-bottom: var(--ds-size-6);
+  .ctaBanner {
+    padding: var(--ds-size-8) var(--ds-size-6);
   }
-
-  .valueButton {
-    margin-top: auto;
-    align-self: flex-start;
-  }
-  
-  /* --- RESPONSIVE MEDIA QUERIES --- */
-  
-  /* Tablet & Up */
-  @media (min-width: 768px) {
-    .bentoWrapper {
-      /* 3 columns for navigation cards */
-      grid-template-columns: repeat(3, 1fr);
-    }
-  
-    .bentoItem {
-      height: 100%;
-      min-height: var(--ds-size-30);
-    }
-  
-    .bentoPreview {
-      display: block; 
-    }
-    
-    .heroTitle {
-      font-size: var(--ds-font-size-10);
-    }
-  }
-  
-  /* Desktop & Up */
-  @media (min-width: 1024px) {
-    .splitLayout {
-      flex-direction: row;
-      align-items: center;
-      justify-content: space-between;
-    }
-    
-    .splitContent {
-      flex: 0 0 45%;
-    }
-    
-    .heroVisual {
-      flex: 1;
-      /* Use tokens for height */
-      height: calc(var(--ds-size-30) * 3.5);
-      justify-content: center;
-      perspective-origin: center right;
-      width:200%;
-    }
-    
-    .gradientOverlay {
-      background: linear-gradient(to right, var(--ds-color-neutral-background-default) 0%, transparent 20%);
-    }
-    
-    .bentoWrapper {
-      gap: var(--ds-size-8);
-    }
-    
-    .valuesGrid {
-      grid-template-columns: repeat(3, 1fr);
-    }
-  }
-
-  @media (max-width: 480px) {
-    .heroSection {
-      padding: var(--ds-size-12) 0 var(--ds-size-10);
-    }
-
-    .heroVisual {
-      display: none;
-    }
-
-    .gridColumn {
-      width: 150px;
-    }
-
-    .sectionValues {
-      padding: var(--ds-size-12) 0;
-    }
-  }
-
-  /* Large Desktop & Up - Better balance for Hero */
-  @media (min-width: 1200px) {
-    .splitLayout {
-      gap: var(--ds-size-16);
-    }
-
-    .splitContent {
-      flex: 0 0 40%;
-    }
-    
-    .heroVisual {
-      flex: 1 / 2;
-    }
-  }
+}

--- a/src/pages/SearchResults/index.tsx
+++ b/src/pages/SearchResults/index.tsx
@@ -1,4 +1,5 @@
 import { useMemo } from 'react';
+import { ArrowRightIcon } from '@navikt/aksel-icons';
 import { Heading } from '../../components/Heading';
 import { Paragraph } from '../../components/Paragraph';
 import { Card } from '../../components/Card';
@@ -16,8 +17,8 @@ export const SearchResultsPage = ({ query, setPage }: SearchResultsPageProps) =>
   const results = useMemo(() => {
     if (!decodedQuery.trim()) return [];
     const lowerQuery = decodedQuery.toLowerCase();
-    return searchIndex.filter(item => 
-      item.title.toLowerCase().includes(lowerQuery) || 
+    return searchIndex.filter(item =>
+      item.title.toLowerCase().includes(lowerQuery) ||
       item.description?.toLowerCase().includes(lowerQuery)
     );
   }, [decodedQuery]);
@@ -28,42 +29,53 @@ export const SearchResultsPage = ({ query, setPage }: SearchResultsPageProps) =>
   };
 
   return (
-    <main className={styles.container}>
-      <div className={styles.header}>
-        <Heading level={1} data-size="xl">
-          Søkeresultater <span className={styles.query}>for "{decodedQuery}"</span>
-        </Heading>
-        <Paragraph data-size="lg">
-          {results.length} {results.length === 1 ? 'treff' : 'treff'} funnet
-        </Paragraph>
+    <main className={styles.pageWrapper}>
+      {/* Hero: inset rounded cream panel (design retning pattern) */}
+      <div className={styles.container}>
+        <header className={styles.heroPanel}>
+          <Heading level={1} className={styles.title}>
+            Søkeresultater <span className={styles.query}>for "{decodedQuery}"</span>
+          </Heading>
+          <Paragraph data-size="lg" className={styles.resultCount}>
+            {results.length} {results.length === 1 ? 'treff' : 'treff'} funnet
+          </Paragraph>
+        </header>
       </div>
 
-      {results.length > 0 ? (
-        <ul className={styles.resultList}>
-          {results.map((result) => (
-            <li key={result.id}>
-              <Card asChild variant="default">
-                <a
-                  href="#"
-                  className={styles.resultLink}
-                  onClick={(e) => handleResultClick(e, result.path)}
-                >
-                  <span className={styles.resultCategory}>{result.category}</span>
-                  <Heading level={2} data-size="md">{result.title}</Heading>
-                  {result.description && (
-                    <Paragraph data-size="sm">{result.description}</Paragraph>
-                  )}
-                </a>
-              </Card>
-            </li>
-          ))}
-        </ul>
-      ) : (
-        <div className={styles.noResults}>
-          <Paragraph data-size="lg">Ingen resultater funnet for "{decodedQuery}". Prøv et annet søkeord.</Paragraph>
-        </div>
-      )}
+      <div className={styles.container}>
+        {results.length > 0 ? (
+          <ul className={styles.resultList}>
+            {results.map((result) => (
+              <li key={result.id}>
+                <Card asChild variant="default" className={styles.resultCard}>
+                  <a
+                    href="#"
+                    className={styles.resultLink}
+                    onClick={(e) => handleResultClick(e, result.path)}
+                  >
+                    <span className={styles.resultCategory}>{result.category}</span>
+                    <Heading level={2} data-size="md" className={styles.resultTitle}>
+                      <span className={styles.resultAction}>
+                        {result.title}
+                        <ArrowRightIcon aria-hidden="true" className={styles.resultArrow} />
+                      </span>
+                    </Heading>
+                    {result.description && (
+                      <Paragraph data-size="sm" className={styles.resultDescription}>
+                        {result.description}
+                      </Paragraph>
+                    )}
+                  </a>
+                </Card>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <div className={styles.noResults}>
+            <Paragraph data-size="lg">Ingen resultater funnet for "{decodedQuery}". Prøv et annet søkeord.</Paragraph>
+          </div>
+        )}
+      </div>
     </main>
   );
 };
-

--- a/src/pages/SearchResults/styles.module.css
+++ b/src/pages/SearchResults/styles.module.css
@@ -1,17 +1,47 @@
+/* Search results — "Design retning" restyle.
+   Shares the card/link language of the Components page. Tokens only. */
+
+.pageWrapper {
+  width: 100%;
+  min-height: 100vh;
+  background-color: var(--ds-color-neutral-background-default);
+  padding-bottom: var(--ds-size-26);
+}
+
 .container {
   width: 100%;
   max-width: 1200px;
   margin: 0 auto;
-  padding: var(--ds-size-8) var(--ds-size-4);
+  padding-left: var(--ds-size-6);
+  padding-right: var(--ds-size-6);
 }
 
-.header {
-  margin-bottom: var(--ds-size-8);
+/* Hero: inset rounded cream panel inside the container (design retning pattern) */
+.heroPanel {
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-size-3);
+  background-color: var(--ds-color-neutral-background-tinted);
+  border-radius: var(--ds-border-radius-xl);
+  padding: var(--ds-size-12) var(--ds-size-10);
+  margin: var(--ds-size-8) 0 var(--ds-size-10);
+}
+
+.title {
+  color: var(--ds-color-primary-color-red-text-default);
+  font-size: var(--ds-font-size-9);
+  font-weight: var(--ds-font-weight-semibold);
+  line-height: var(--ds-line-height-sm);
+  overflow-wrap: anywhere;
 }
 
 .query {
   color: var(--ds-color-neutral-text-subtle);
   font-weight: var(--ds-font-weight-regular);
+}
+
+.resultCount {
+  color: var(--ds-color-neutral-text-subtle);
 }
 
 .resultList {
@@ -23,36 +53,118 @@
   gap: var(--ds-size-4);
 }
 
-/* Anchor-as-Card: layout-only. Card handles background/border/radius/hover. */
+/* Card-as-link: soft cream card, xl radius, pink-tinted border on hover.
+   Doubled class selector so these visuals win over ds-card defaults. */
+.resultCard.resultCard {
+  display: block;
+  background-color: var(--ds-color-neutral-background-tinted);
+  border: var(--ds-border-width-default) solid var(--ds-color-neutral-background-tinted);
+  border-radius: var(--ds-border-radius-xl);
+  overflow: hidden;
+  text-decoration: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.resultCard.resultCard:hover,
+.resultCard.resultCard:focus-visible {
+  border-color: var(--ds-color-primary-color-red-border-subtle);
+  box-shadow: var(--ds-shadow-md);
+}
+
 .resultLink {
   display: flex;
   flex-direction: column;
+  align-items: flex-start;
   gap: var(--ds-size-2);
 }
 
+/* Small pink accent pill for the category label */
 .resultCategory {
-  font-size: var(--ds-font-size-sm);
-  color: var(--ds-color-neutral-text-subtle);
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
+  display: inline-flex;
+  align-items: center;
+  background-color: var(--ds-color-primary-color-red-surface-tinted);
+  color: var(--ds-color-primary-color-red-text-default);
+  font-size: var(--ds-font-size-1);
   font-weight: var(--ds-font-weight-medium);
+  text-transform: uppercase;
+  padding: var(--ds-size-1) var(--ds-size-3);
+  border-radius: var(--ds-border-radius-full);
 }
 
+.resultTitle {
+  display: flex;
+}
+
+/* Text-button language: maroon title + arrow, pink pill appears on hover/focus */
+.resultAction {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ds-size-2);
+  color: var(--ds-color-primary-color-red-text-default);
+  padding: var(--ds-size-1) var(--ds-size-4);
+  margin-left: calc(-1 * var(--ds-size-4));
+  border-radius: var(--ds-border-radius-full);
+  transition: background-color 0.2s ease;
+}
+
+.resultArrow {
+  flex-shrink: 0;
+  transition: transform 0.2s ease;
+}
+
+.resultCard:hover .resultAction,
+.resultCard:focus-visible .resultAction {
+  background-color: var(--ds-color-primary-color-red-surface-hover);
+}
+
+.resultCard:hover .resultArrow {
+  transform: translateX(var(--ds-size-1));
+}
+
+.resultDescription {
+  color: var(--ds-color-neutral-text-subtle);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .resultCard.resultCard,
+  .resultAction,
+  .resultArrow {
+    transition: none;
+  }
+
+  .resultCard:hover .resultArrow {
+    transform: none;
+  }
+}
+
+/* Empty state: soft cream panel */
 .noResults {
   text-align: center;
   padding: var(--ds-size-12);
   color: var(--ds-color-neutral-text-subtle);
+  background-color: var(--ds-color-neutral-background-tinted);
+  border-radius: var(--ds-border-radius-xl);
 }
 
 @media (max-width: 768px) {
   .container {
-    padding: var(--ds-size-6) var(--ds-size-3);
+    padding-left: var(--ds-size-4);
+    padding-right: var(--ds-size-4);
+  }
+
+  .heroPanel {
+    padding: var(--ds-size-8) var(--ds-size-5);
+    margin-top: var(--ds-size-4);
+  }
+
+  .title {
+    font-size: var(--ds-font-size-7);
   }
 }
 
 @media (max-width: 480px) {
   .container {
-    padding: var(--ds-size-4) var(--ds-size-2);
+    padding-left: var(--ds-size-3);
+    padding-right: var(--ds-size-3);
   }
 }
-

--- a/src/pages/Tokens/index.tsx
+++ b/src/pages/Tokens/index.tsx
@@ -2,7 +2,6 @@ import { useEffect, useState, useMemo } from 'react';
 import { useLanguage } from '../../context/LanguageContext';
 import { Heading } from '../../components/Heading';
 import { Paragraph } from '../../components/Paragraph';
-import { Card, CardBlock } from '../../components/Card';
 import styles from './styles.module.css';
 
 interface Token {
@@ -343,125 +342,129 @@ export const TokensPage = () => {
     : [];
 
   return (
-    <main className={`container ${styles.docLayout}`}>
-      {/* --- SIDEBAR TOGGLE (mobile only) --- */}
-      <button
-        className={styles.sidebarToggle}
-        onClick={() => setSidebarOpen(!sidebarOpen)}
-        aria-expanded={sidebarOpen}
-      >
-        {categoryLabels[activeCategory] || t('tokensPage.categoriesLabel')}
-      </button>
+    <main className={styles.page}>
+      {/* --- HERO — inset rounded cream panel inside the container --- */}
+      <header className={`container ${styles.heroWrap}`}>
+        <div className={styles.heroPanel}>
+          <Heading level={1} data-size="xl" className={styles.pageTitle}>{t('tokensPage.title')}</Heading>
+          <Paragraph data-size="lg" className={styles.pageDescription}>
+            {t('tokensPage.description')}
+          </Paragraph>
+        </div>
+      </header>
 
-      {/* --- SIDEBAR --- */}
-      <aside className={`${styles.sidebar} ${!sidebarOpen ? styles.sidebarCollapsed : ''}`}>
-        <nav className={styles.nav}>
-          <div className={styles.group}>
-            <div className={styles.navGroupLabel}>{t('tokensPage.categoriesLabel')}</div>
-            <ul className={styles.list}>
-              {sortedCategories.map((category) => (
-                <li key={category} className={styles.listItem}>
-                  <button
-                    type="button"
-                    className={`${styles.link} ${activeCategory === category ? styles.linkActive : ''}`}
-                    onClick={() => {
-                      setActiveCategory(category);
-                      setSidebarOpen(false);
-                    }}
-                  >
-                    {categoryLabels[category]}
-                  </button>
-                </li>
-              ))}
-            </ul>
-          </div>
-        </nav>
-      </aside>
+      <div className={`container ${styles.docLayout}`}>
+        {/* --- SIDEBAR TOGGLE (mobile only) --- */}
+        <button
+          className={styles.sidebarToggle}
+          onClick={() => setSidebarOpen(!sidebarOpen)}
+          aria-expanded={sidebarOpen}
+        >
+          {categoryLabels[activeCategory] || t('tokensPage.categoriesLabel')}
+        </button>
 
-      {/* --- MAIN CONTENT AREA --- */}
-      <div className={styles.docContent}>
-        <Heading level={1} data-size="xl" className={styles.pageTitle}>{t('tokensPage.title')}</Heading>
-        <Paragraph data-size="lg" className={styles.pageDescription}>
-          {t('tokensPage.description')}
-        </Paragraph>
-        <hr className={styles.pageDivider} />
+        {/* --- SIDEBAR --- */}
+        <aside className={`${styles.sidebar} ${!sidebarOpen ? styles.sidebarCollapsed : ''}`}>
+          <nav className={styles.nav}>
+            <div className={styles.group}>
+              <div className={styles.navGroupLabel}>{t('tokensPage.categoriesLabel')}</div>
+              <ul className={styles.list}>
+                {sortedCategories.map((category) => (
+                  <li key={category} className={styles.listItem}>
+                    <button
+                      type="button"
+                      className={`${styles.link} ${activeCategory === category ? styles.linkActive : ''}`}
+                      onClick={() => {
+                        setActiveCategory(category);
+                        setSidebarOpen(false);
+                      }}
+                    >
+                      {categoryLabels[category]}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </nav>
+        </aside>
 
-        {structuredGroups[activeCategory] && (
-          <section className={styles.categorySection}>
-            <Heading level={2} data-size="lg" className={styles.categoryTitle}>
-              {categoryLabels[activeCategory]}
-            </Heading>
+        {/* --- MAIN CONTENT AREA --- */}
+        <div className={styles.docContent}>
+          {structuredGroups[activeCategory] && (
+            <section className={styles.categorySection}>
+              <Heading level={2} data-size="lg" className={styles.categoryTitle}>
+                {categoryLabels[activeCategory]}
+              </Heading>
 
-            {currentGroupKeys.map(groupKey => {
-              const group = structuredGroups[activeCategory][groupKey];
-              return (
-                <div key={groupKey} className={styles.tokenGroup}>
-                  <Heading level={3} data-size="sm" className={styles.groupHeading}>
-                    {formatGroupName(group.name)}
-                  </Heading>
+              {currentGroupKeys.map(groupKey => {
+                const group = structuredGroups[activeCategory][groupKey];
+                return (
+                  <section key={groupKey} className={styles.tokenGroup}>
+                    <Heading level={3} data-size="sm" className={styles.groupHeading}>
+                      {formatGroupName(group.name)}
+                    </Heading>
 
-                  {activeCategory === 'colors' ? (
-                    <div className={styles.tokensGrid}>
-                      {group.tokens.map((token, index) => (
-                        <Card key={index} className={styles.tokenCard} data-color="neutral">
-                          <CardBlock>
-                            <div className={styles.colorSwatchContainer}>
-                              <span
-                                className={styles.colorSwatch}
-                                style={{ backgroundColor: token.value }}
-                                aria-label={t('tokensPage.colorPreviewLabel').replace('{value}', token.value)}
-                              />
-                              <button
-                                className={styles.copyButton}
-                                onClick={() => copyToClipboard(token.name)}
-                                aria-label={t('tokensPage.copyTokenLabel').replace('{name}', token.name)}
-                                title={`Copy ${token.name}`}
-                              >
+                    <div className={styles.groupPanel}>
+                    {activeCategory === 'colors' ? (
+                      <ul className={styles.swatchGrid}>
+                        {group.tokens.map((token, index) => (
+                          <li key={index} className={styles.swatchItem}>
+                            <span
+                              className={styles.swatchCircle}
+                              style={{ backgroundColor: token.value }}
+                              role="img"
+                              aria-label={t('tokensPage.colorPreviewLabel').replace('{value}', token.value)}
+                            />
+                            <button
+                              type="button"
+                              className={styles.swatchCopy}
+                              onClick={() => copyToClipboard(token.name)}
+                              aria-label={t('tokensPage.copyTokenLabel').replace('{name}', token.name)}
+                              title={`Copy ${token.name}`}
+                            >
+                              <span className={styles.swatchValue}>
+                                {token.value}
                                 <CopyIcon />
-                              </button>
-                            </div>
-                            <div className={styles.tokenInfo}>
-                              <code className={styles.tokenName} title={token.name}>
+                              </span>
+                              <code className={styles.swatchName} title={token.name}>
                                 {token.name}
                               </code>
-                              <code className={styles.tokenValue} title={token.value}>
-                                {token.value}
-                              </code>
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
+                    ) : (
+                      <ul className={styles.tokenList}>
+                        {group.tokens.map((token, index) => (
+                          <li key={index} className={styles.tokenRow}>
+                            <code className={styles.tokenRowName} title={token.name}>
+                              {token.name}
+                            </code>
+                            <div className={styles.tokenRowPreview}>
+                              {renderPreview(token)}
                             </div>
-                          </CardBlock>
-                        </Card>
-                      ))}
+                            <code className={styles.tokenRowValue} title={token.value}>
+                              {token.value}
+                            </code>
+                            <button
+                              className={styles.copyButtonInline}
+                              onClick={() => copyToClipboard(token.name)}
+                              aria-label={t('tokensPage.copyTokenLabel').replace('{name}', token.name)}
+                              title={`Copy ${token.name}`}
+                            >
+                              <CopyIcon />
+                            </button>
+                          </li>
+                        ))}
+                      </ul>
+                    )}
                     </div>
-                  ) : (
-                    <ul className={styles.tokenList}>
-                      {group.tokens.map((token, index) => (
-                        <li key={index} className={styles.tokenRow}>
-                          <code className={styles.tokenRowName} title={token.name}>
-                            {token.name}
-                          </code>
-                          <div className={styles.tokenRowPreview}>
-                            {renderPreview(token)}
-                          </div>
-                          <code className={styles.tokenRowValue} title={token.value}>
-                            {token.value}
-                          </code>
-                          <button
-                            className={styles.copyButtonInline}
-                            onClick={() => copyToClipboard(token.name)}
-                            aria-label={t('tokensPage.copyTokenLabel').replace('{name}', token.name)}
-                            title={`Copy ${token.name}`}
-                          >
-                            <CopyIcon />
-                          </button>
-                        </li>
-                      ))}
-                    </ul>
-                  )}
-                </div>
-              );
-            })}
-          </section>
-        )}
+                  </section>
+                );
+              })}
+            </section>
+          )}
+        </div>
       </div>
     </main>
   );

--- a/src/pages/Tokens/styles.module.css
+++ b/src/pages/Tokens/styles.module.css
@@ -1,13 +1,47 @@
+.page {
+  width: 100%;
+}
+
+/* --- HERO — inset rounded cream panel (concept listing-page pattern) --- */
+.heroWrap {
+  padding-top: var(--ds-size-8);
+}
+
+.heroPanel {
+  position: relative;
+  overflow: hidden;
+  background-color: var(--ds-color-neutral-background-tinted);
+  border-radius: var(--ds-border-radius-xl);
+  padding: var(--ds-size-15) var(--ds-size-12);
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-size-5);
+}
+
+.pageTitle {
+  margin: 0;
+  color: var(--ds-color-primary-color-red-text-default);
+  font-size: var(--ds-font-size-10);
+  font-weight: var(--ds-font-weight-semibold);
+}
+
+.pageDescription {
+  margin: 0;
+  color: var(--ds-color-neutral-text-subtle);
+  max-width: 65ch;
+}
+
+/* --- DOC LAYOUT --- */
 .docLayout {
   display: flex;
   gap: var(--ds-size-10);
-  padding: 0 0 var(--ds-size-8) 0;
-  min-height: 600px;
+  padding-top: var(--ds-size-12);
+  padding-bottom: var(--ds-size-18);
   align-items: flex-start;
 }
 
 .sidebar {
-  width: 280px;
+  width: calc(var(--ds-size-30) * 2 + var(--ds-size-10));
   flex-shrink: 0;
   position: sticky;
   top: var(--ds-size-6);
@@ -16,12 +50,11 @@
   overflow-y: auto;
   overflow-x: hidden;
   padding-right: var(--ds-size-4);
-  padding-top: var(--ds-size-10);
 }
 
 /* Custom Scrollbar for Sidebar */
 .sidebar::-webkit-scrollbar {
-  width: 6px;
+  width: var(--ds-size-2);
 }
 
 .sidebar::-webkit-scrollbar-track {
@@ -30,7 +63,7 @@
 
 .sidebar::-webkit-scrollbar-thumb {
   background-color: var(--ds-color-neutral-border-subtle);
-  border-radius: 3px;
+  border-radius: var(--ds-border-radius-full);
 }
 
 .nav {
@@ -45,24 +78,26 @@
 }
 
 .navGroupLabel {
-  font-size: var(--ds-font-size-sm, 14px);
-  font-weight: var(--ds-font-weight-bold, 700);
-  color: var(--ds-color-neutral-text-subtle, #5d5d5d);
+  font-size: var(--ds-font-size-1);
+  font-weight: var(--ds-font-weight-semibold);
+  color: var(--ds-color-neutral-text-subtle);
   text-transform: uppercase;
   letter-spacing: 0.05em;
-  margin-bottom: var(--ds-size-2, 8px);
-  padding-left: var(--ds-size-3, 12px);
-  border-left: 4px solid var(--ds-color-primary-color-red-base-default);
+  margin-bottom: var(--ds-size-3);
+  padding-left: var(--ds-size-5);
 }
 
 .list {
   list-style: none;
   padding: 0;
   margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-size-1);
 }
 
 .listItem {
-  margin-bottom: 2px;
+  margin: 0;
 }
 
 .link {
@@ -70,12 +105,13 @@
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  padding: var(--ds-size-2) var(--ds-size-3);
-  font-size: var(--ds-font-size-md);
+  padding: var(--ds-size-2) var(--ds-size-5);
+  font-size: var(--ds-font-size-3);
   color: var(--ds-color-neutral-text-default);
   text-decoration: none;
-  border-radius: var(--ds-border-radius-md);
-  transition: all 0.2s ease;
+  border-radius: var(--ds-border-radius-full);
+  transition: background-color var(--ds-duration-fast) var(--ds-ease-standard),
+    color var(--ds-duration-fast) var(--ds-ease-standard);
   background: transparent;
   border: none;
   text-align: left;
@@ -84,87 +120,28 @@
 }
 
 .link:hover {
-  background-color: var(--ds-color-neutral-surface-hover);
+  background-color: var(--ds-color-neutral-background-tinted);
   color: var(--ds-color-neutral-text-default);
 }
 
 .linkActive {
-  background-color: var(--ds-color-primary-surface-subtle);
-  color: var(--ds-color-primary-text-default);
-  font-weight: var(--ds-font-weight-medium);
+  background-color: var(--ds-color-primary-color-red-surface-tinted);
+  color: var(--ds-color-primary-color-red-text-default);
+  font-weight: var(--ds-font-weight-semibold);
 }
 
-.details > summary {
-  list-style: none;
-}
-
-.details > summary::-webkit-details-marker {
-  display: none;
-}
-
-.nestedList {
-  list-style: none;
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-  padding-left: var(--ds-size-3);
-  margin-top: 2px;
-  border-left: 1px solid var(--ds-color-neutral-border-subtle);
-  margin-left: var(--ds-size-3);
-}
-
-.nestedLink {
-  font-size: var(--ds-font-size-sm);
-  padding: var(--ds-size-2) var(--ds-size-3);
-  color: var(--ds-color-neutral-text-subtle);
-}
-
-.nestedLink:hover {
-  color: var(--ds-color-neutral-text-default);
-  background-color: var(--ds-color-neutral-surface-hover);
-}
-
-.nestedLinkActive {
-  color: var(--ds-color-primary-text-default);
-  background-color: var(--ds-color-primary-surface-subtle);
-  font-weight: var(--ds-font-weight-medium);
-  border-left: 2px solid var(--ds-color-primary-base-default);
-  border-top-left-radius: 0;
-  border-bottom-left-radius: 0;
-  margin-left: -1px; /* Overlap border */
+.linkActive:hover {
+  background-color: var(--ds-color-primary-color-red-surface-hover);
+  color: var(--ds-color-primary-color-red-text-default);
 }
 
 .docContent {
   flex: 1;
-  padding-left: var(--ds-size-10);
-  border-left: 1px solid var(--ds-color-neutral-border-subtle);
   min-width: 0;
-  padding-top: var(--ds-size-18);
-}
-
-.pageTitle {
-  margin-bottom: var(--ds-size-4);
-  color: var(--ds-color-neutral-text-default);
-}
-
-.pageDescription {
-  margin-bottom: var(--ds-size-8);
-  color: var(--ds-color-neutral-text-subtle);
-  max-width: 65ch;
-}
-
-.pageDivider {
-  border: 0;
-  border-bottom: 1px solid var(--ds-color-neutral-border-subtle);
-  margin: 0 0 var(--ds-size-10) 0;
 }
 
 .categorySection {
-  margin-bottom: var(--ds-size-32);
-}
-
-.categorySection:first-child {
-  margin-top: 0;
+  margin-bottom: var(--ds-size-18);
 }
 
 .categorySection:last-child {
@@ -172,100 +149,189 @@
 }
 
 .categoryTitle {
-  margin-bottom: var(--ds-size-12);
-  margin-top: var(--ds-size-10);
-  color: var(--ds-color-neutral-text-default);
-  font-weight: var(--ds-font-weight-bold);
-  padding-bottom: var(--ds-size-5);
-  border-bottom: 2px solid var(--ds-color-neutral-border-default);
-}
-
-.categorySection:first-child .categoryTitle {
   margin-top: 0;
-}
-
-.tokenGroup {
-  margin-bottom: var(--ds-size-20);
-  margin-top: var(--ds-size-8);
-}
-
-.tokenGroup:first-child {
-  margin-top: 0;
-}
-
-.groupHeading {
-  margin-bottom: var(--ds-size-8);
-  margin-top: var(--ds-size-6);
+  margin-bottom: var(--ds-size-10);
   color: var(--ds-color-neutral-text-default);
+  font-size: var(--ds-font-size-8);
   font-weight: var(--ds-font-weight-semibold);
-  font-size: var(--ds-heading-sm-font-size);
-  padding-left: var(--ds-size-3);
-  border-left: 4px solid var(--ds-color-primary-color-red-base-default);
 }
 
-.tokensGrid {
+/* --- TOKEN GROUPS — heading directly above grid, alternating inset cream panels --- */
+.tokenGroup {
+  margin-bottom: var(--ds-size-12);
+}
+
+.tokenGroup:last-child {
+  margin-bottom: 0;
+}
+
+/* Section heading row: maroon semibold, sits on white directly above the grid */
+.groupHeading {
+  margin-top: 0;
+  margin-bottom: var(--ds-size-5);
+  color: var(--ds-color-primary-color-red-text-default);
+  font-size: var(--ds-font-size-5);
+  font-weight: var(--ds-font-weight-semibold);
+}
+
+/* Even groups get the inset rounded cream panel; the first group stays on white
+   so it doesn't stack against the cream hero panel above */
+.tokenGroup:nth-of-type(even) .groupPanel {
+  background-color: var(--ds-color-neutral-background-tinted);
+  border-radius: var(--ds-border-radius-xl);
+  padding: var(--ds-size-8);
+}
+
+/* --- COLOR SWATCHES — soft circles, Figma "Utvidet fargepalett" --- */
+.swatchGrid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  grid-template-columns: repeat(auto-fill, minmax(calc(var(--ds-size-30) + var(--ds-size-10)), 1fr));
+  gap: var(--ds-size-8) var(--ds-size-4);
+}
+
+.swatchItem {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   gap: var(--ds-size-4);
-  margin-top: var(--ds-size-4);
+  min-width: 0;
 }
 
-.tokenCard {
-  position: relative;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+.swatchCircle {
+  display: block;
+  width: var(--ds-size-22);
+  height: var(--ds-size-22);
+  border-radius: var(--ds-border-radius-full);
+  box-shadow: inset 0 0 0 var(--ds-border-width-default) var(--ds-color-neutral-border-subtle);
+  flex-shrink: 0;
+  transition: transform var(--ds-duration-base) var(--ds-ease-emphasized);
 }
 
-.tokenCard:hover {
-  transform: translateY(-2px);
-  box-shadow: var(--ds-shadow-md);
+.swatchItem:hover .swatchCircle {
+  transform: scale(1.05);
 }
 
-.colorSwatchContainer {
-  position: relative;
-  margin-bottom: var(--ds-size-6);
-  margin-top: calc(-1 * var(--ds-size-4));
-  margin-left: calc(-1 * var(--ds-size-4));
-  margin-right: calc(-1 * var(--ds-size-4));
-  border-radius: var(--ds-border-radius-md) var(--ds-border-radius-md) 0 0;
+.swatchCopy {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--ds-size-1);
+  width: 100%;
+  min-width: 0;
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  font-family: inherit;
+  text-align: center;
+  color: inherit;
+  border-radius: var(--ds-border-radius-lg);
+}
+
+.swatchValue {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--ds-size-2);
+  padding: var(--ds-size-1) var(--ds-size-3);
+  border-radius: var(--ds-border-radius-full);
+  font-size: var(--ds-font-size-2);
+  font-weight: var(--ds-font-weight-medium);
+  color: var(--ds-color-neutral-text-default);
+  transition: background-color var(--ds-duration-fast) var(--ds-ease-standard),
+    color var(--ds-duration-fast) var(--ds-ease-standard);
+  max-width: 100%;
+  overflow-wrap: anywhere;
+}
+
+.swatchValue svg {
+  width: var(--ds-size-4);
+  height: var(--ds-size-4);
+  flex-shrink: 0;
+  color: var(--ds-color-neutral-text-subtle);
+  transition: color var(--ds-duration-fast) var(--ds-ease-standard);
+}
+
+.swatchCopy:hover .swatchValue {
+  background-color: var(--ds-color-primary-color-red-surface-hover);
+  color: var(--ds-color-primary-color-red-text-default);
+}
+
+.swatchCopy:hover .swatchValue svg {
+  color: var(--ds-color-primary-color-red-text-default);
+}
+
+.swatchCopy:active .swatchValue {
+  background-color: var(--ds-color-primary-color-red-surface-active);
+}
+
+.swatchName {
+  font-family: inherit;
+  font-size: var(--ds-font-size-1);
+  line-height: var(--ds-line-height-md);
+  color: var(--ds-color-neutral-text-subtle);
+  overflow-wrap: anywhere;
+  max-width: 100%;
+}
+
+/* --- LIST VIEW (non-color tokens) --- */
+.tokenList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--ds-size-2);
+}
+
+.tokenRow {
+  display: grid;
+  grid-template-columns: minmax(calc(var(--ds-size-30) + var(--ds-size-26)), 1.5fr) minmax(var(--ds-size-30), 1fr) minmax(calc(var(--ds-size-30) + var(--ds-size-5)), auto) auto;
+  align-items: center;
+  gap: var(--ds-size-5);
+  padding: var(--ds-size-4) var(--ds-size-6);
+  background: var(--ds-color-neutral-background-tinted);
+  border-radius: var(--ds-border-radius-lg);
+  transition: background-color var(--ds-duration-fast) var(--ds-ease-standard);
+}
+
+/* Rows are cream on white groups; flip to white inside cream panels for contrast */
+.tokenGroup:nth-of-type(even) .tokenRow {
+  background: var(--ds-color-neutral-background-default);
+}
+
+.tokenRow:hover {
+  background: var(--ds-color-primary-color-red-surface-tinted);
+}
+
+.tokenRowName {
+  font-family: inherit;
+  font-size: var(--ds-font-size-2);
+  color: var(--ds-color-neutral-text-default);
+  font-weight: var(--ds-font-weight-medium);
+  overflow-wrap: anywhere;
+}
+
+.tokenRowPreview {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  min-height: var(--ds-size-10);
   overflow: hidden;
 }
 
-.colorSwatch {
-  display: inline-block;
-  width: 100%;
-  height: 100px;
-  border: none;
-  flex-shrink: 0;
-  position: relative;
-}
-
-.tokenInfo {
-  display: flex;
-  flex-direction: column;
-  gap: var(--ds-size-3);
-  flex: 1;
-}
-
-.tokenName {
-  font-family: 'Courier New', monospace;
-  font-size: var(--ds-body-sm-font-size);
-  word-break: break-all;
-  line-height: 1.6;
-  color: var(--ds-color-neutral-text-default);
-  font-weight: var(--ds-font-weight-medium);
-  display: block;
-}
-
-.tokenValue {
-  font-family: 'Courier New', monospace;
-  font-size: var(--ds-body-xs-font-size);
-  word-break: break-all;
-  line-height: 1.5;
+.tokenRowValue {
+  font-family: inherit;
+  font-size: var(--ds-font-size-2);
   color: var(--ds-color-neutral-text-subtle);
-  display: block;
+  justify-self: end;
+  text-align: right;
+  overflow-wrap: anywhere;
 }
 
-.copyButton,
+/* --- COPY BUTTON (list rows) --- */
 .copyButtonInline {
   background: transparent;
   border: none;
@@ -275,92 +341,24 @@
   align-items: center;
   justify-content: center;
   color: var(--ds-color-neutral-text-subtle);
-  border-radius: var(--ds-border-radius-sm);
-  transition: background-color 0.2s ease, color 0.2s ease;
+  border-radius: var(--ds-border-radius-full);
+  transition: background-color var(--ds-duration-fast) var(--ds-ease-standard),
+    color var(--ds-duration-fast) var(--ds-ease-standard);
   flex-shrink: 0;
 }
 
-.copyButton {
-  position: absolute;
-  top: var(--ds-size-3);
-  right: var(--ds-size-3);
-  background-color: rgba(255, 255, 255, 0.95);
-  backdrop-filter: blur(8px);
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
-}
-
-.copyButtonInline {
-  margin-top: var(--ds-size-2);
-  align-self: flex-start;
-}
-
-.copyButton:hover,
 .copyButtonInline:hover {
-  background-color: var(--ds-color-neutral-background-tinted);
-  color: var(--ds-color-neutral-text-default);
+  background-color: var(--ds-color-primary-color-red-surface-hover);
+  color: var(--ds-color-primary-color-red-text-default);
 }
 
-.copyButton:active,
 .copyButtonInline:active {
-  transform: scale(0.95);
+  background-color: var(--ds-color-primary-color-red-surface-active);
 }
 
-.copyButton svg,
 .copyButtonInline svg {
-  width: 16px;
-  height: 16px;
-}
-
-/* --- LIST VIEW (non-color tokens) --- */
-.tokenList {
-  list-style: none;
-  padding: 0;
-  margin: var(--ds-size-4) 0 0 0;
-  display: flex;
-  flex-direction: column;
-  gap: var(--ds-size-2);
-}
-
-.tokenRow {
-  display: grid;
-  grid-template-columns: minmax(220px, 1.5fr) minmax(120px, 1fr) minmax(140px, auto) auto;
-  align-items: center;
-  gap: var(--ds-size-5);
-  padding: var(--ds-size-3) var(--ds-size-5);
-  background: var(--ds-color-neutral-background-default);
-  border: 1px solid var(--ds-color-neutral-border-subtle);
-  border-radius: var(--ds-border-radius-md);
-  transition: background-color 0.15s ease, border-color 0.15s ease;
-}
-
-.tokenRow:hover {
-  background: var(--ds-color-neutral-surface-hover);
-  border-color: var(--ds-color-neutral-border-default);
-}
-
-.tokenRowName {
-  font-family: 'Courier New', monospace;
-  font-size: var(--ds-body-sm-font-size);
-  color: var(--ds-color-neutral-text-default);
-  font-weight: var(--ds-font-weight-medium);
-  word-break: break-all;
-}
-
-.tokenRowPreview {
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  min-height: 40px;
-  overflow: hidden;
-}
-
-.tokenRowValue {
-  font-family: 'Courier New', monospace;
-  font-size: var(--ds-body-sm-font-size);
-  color: var(--ds-color-neutral-text-subtle);
-  justify-self: end;
-  text-align: right;
-  word-break: break-all;
+  width: var(--ds-size-4);
+  height: var(--ds-size-4);
 }
 
 /* Size / spacing preview */
@@ -371,62 +369,69 @@
 }
 
 .sizeBar {
-  height: 14px;
+  height: var(--ds-size-3);
   background: var(--ds-color-primary-color-red-base-default);
-  border-radius: var(--ds-border-radius-sm);
+  border-radius: var(--ds-border-radius-full);
   max-width: 100%;
 }
 
 /* Border radius preview */
 .radiusBox {
-  width: 48px;
-  height: 48px;
-  background: var(--ds-color-neutral-surface-tinted);
-  border: 1px solid var(--ds-color-neutral-border-default);
+  width: var(--ds-size-12);
+  height: var(--ds-size-12);
+  background: var(--ds-color-primary-color-red-surface-tinted);
+  border: var(--ds-border-width-default) solid var(--ds-color-primary-color-red-border-subtle);
 }
 
 /* Border width preview */
 .borderLine {
-  width: 72px;
+  width: var(--ds-size-18);
   border-top-style: solid;
   border-top-color: var(--ds-color-neutral-text-default);
 }
 
 /* Shadow preview */
 .shadowBox {
-  width: 72px;
-  height: 48px;
+  width: var(--ds-size-18);
+  height: var(--ds-size-12);
   background: var(--ds-color-neutral-background-default);
-  border: 1px solid var(--ds-color-neutral-border-subtle);
-  border-radius: var(--ds-border-radius-sm);
+  border-radius: var(--ds-border-radius-md);
 }
 
 /* Opacity preview */
 .opacityBox {
-  width: 64px;
-  height: 32px;
+  width: var(--ds-size-15);
+  height: var(--ds-size-8);
   background: var(--ds-color-primary-color-red-base-default);
-  border-radius: var(--ds-border-radius-sm);
+  border-radius: var(--ds-border-radius-full);
 }
 
 /* Typography preview */
 .typeSample {
-  font-family: var(--ds-font-family-body, sans-serif);
   color: var(--ds-color-neutral-text-default);
   line-height: 1;
   white-space: nowrap;
+}
+
+/* --- FOCUS (token-driven) --- */
+.link:focus-visible,
+.swatchCopy:focus-visible,
+.copyButtonInline:focus-visible,
+.sidebarToggle:focus-visible {
+  outline: var(--ds-border-width-focus) solid var(--ds-color-focus-outer);
+  outline-offset: calc(var(--ds-size-1) / 2);
 }
 
 /* Sidebar toggle button — hidden on desktop */
 .sidebarToggle {
   display: none;
   width: 100%;
-  padding: var(--ds-size-3) var(--ds-size-4);
-  background: var(--ds-color-neutral-surface-tinted);
-  border: 1px solid var(--ds-color-neutral-border-subtle);
-  border-radius: var(--ds-border-radius-md);
+  padding: var(--ds-size-3) var(--ds-size-5);
+  background: var(--ds-color-neutral-background-tinted);
+  border: none;
+  border-radius: var(--ds-border-radius-full);
   font-family: inherit;
-  font-size: var(--ds-font-size-md);
+  font-size: var(--ds-font-size-3);
   font-weight: var(--ds-font-weight-medium);
   color: var(--ds-color-neutral-text-default);
   cursor: pointer;
@@ -443,10 +448,22 @@
 }
 
 @media (max-width: 768px) {
+  .heroWrap {
+    padding-top: var(--ds-size-5);
+  }
+
+  .heroPanel {
+    padding: var(--ds-size-10) var(--ds-size-6);
+  }
+
+  .pageTitle {
+    font-size: var(--ds-font-size-8);
+  }
+
   .docLayout {
     flex-direction: column;
     gap: 0;
-    min-height: auto;
+    padding-top: var(--ds-size-6);
   }
 
   .sidebar {
@@ -454,10 +471,8 @@
     position: static;
     max-height: none;
     overflow: visible;
-    border-bottom: 1px solid var(--ds-color-neutral-border-subtle);
     padding-right: 0;
-    padding-top: var(--ds-size-4);
-    padding-bottom: var(--ds-size-4);
+    padding-bottom: var(--ds-size-6);
   }
 
   .sidebarCollapsed {
@@ -466,16 +481,25 @@
 
   .sidebarToggle {
     display: block;
+    margin-bottom: var(--ds-size-4);
   }
 
   .docContent {
-    padding-left: 0;
-    padding-top: var(--ds-size-6);
-    border-left: none;
+    padding-top: var(--ds-size-2);
   }
 
-  .tokensGrid {
-    grid-template-columns: 1fr;
+  .tokenGroup:nth-of-type(even) .groupPanel {
+    padding: var(--ds-size-6) var(--ds-size-4);
+  }
+
+  .swatchGrid {
+    grid-template-columns: repeat(auto-fill, minmax(calc(var(--ds-size-26) + var(--ds-size-4)), 1fr));
+    gap: var(--ds-size-6) var(--ds-size-3);
+  }
+
+  .swatchCircle {
+    width: var(--ds-size-18);
+    height: var(--ds-size-18);
   }
 
   .tokenRow {
@@ -496,4 +520,3 @@
   }
   .tokenRow .copyButtonInline { grid-area: copy; }
 }
-

--- a/src/translations/index.ts
+++ b/src/translations/index.ts
@@ -35,6 +35,16 @@ export const translations = {
     home: {
       heroTitle: "Røde Kors Designsystem",
       heroLead: "Felles komponentbibliotek og retningslinjer for design og utvikling av digitale løsninger i Røde Kors.",
+      hero: {
+        kicker: "For designere og utviklere",
+        title: "Ett felles designspråk for Røde Kors",
+        lead: "Ferdige React-komponenter, designtokens og retningslinjer — bygget på Digdir Designsystemet og tilpasset Røde Kors sin visuelle identitet.",
+        primaryCta: "Kom i gang",
+        secondaryCta: "Utforsk komponenter",
+        specimenButton: "Bli frivillig",
+        breadcrumbLabel: "Du er her",
+        breadcrumbHome: "Hjem"
+      },
       searchComponents: "Søk i komponenter",
       exploreSystem: "Utforsk systemet",
       componentsDesc: "Bibliotek med ferdige React-komponenter.",
@@ -43,6 +53,11 @@ export const translations = {
       tokensDesc: "Design tokens, farger og spacing.",
       universalDesign: "Universell utforming",
       universalDesignText: "Innebygd tilgjengelighet som standard. Vi følger WCAG 2.1-kravene strengt.",
+      palette: {
+        title: "Varme farger",
+        lead: "Fargepaletten er utvidet med varme, nøytrale toner som komplementerer rød uten å konkurrere med den — og gir flaten mer pust.",
+        link: "Se alle tokens"
+      },
       readGuidelines: "Les retningslinjene",
       consistentBrand: "Konsistent merkevare",
       consistentBrandText: "Design tokens sikrer at Røde Kors sin visuelle profil ivaretas på alle flater.",
@@ -116,7 +131,11 @@ export const translations = {
       intro: "Designsystemet inneholder grunnleggende komponenter som kan settes sammen på mange ulike måter og i forskjellige mønstre.",
       searchPlaceholder: "Søk etter komponent...",
       searchAriaLabel: "Søk i komponenter",
-      noResults: "Ingen komponenter funnet for"
+      noResults: "Ingen komponenter funnet for",
+      openLabel: "Les mer",
+      ctaTitle: "Utforsk komponentene i Storybook",
+      ctaText: "Se alle varianter, tilstander og kodeeksempler i den interaktive dokumentasjonen.",
+      ctaButton: "Åpne Storybook"
     },
     // Code Page
     code: {
@@ -1057,6 +1076,16 @@ export const translations = {
     home: {
       heroTitle: "Red Cross Design System",
       heroLead: "Common component library and guidelines for design and development of digital solutions in Red Cross.",
+      hero: {
+        kicker: "For designers and developers",
+        title: "One shared design language for the Red Cross",
+        lead: "Ready-made React components, design tokens and guidelines — built on the Digdir Design System and tailored to the Red Cross visual identity.",
+        primaryCta: "Get started",
+        secondaryCta: "Explore components",
+        specimenButton: "Volunteer",
+        breadcrumbLabel: "You are here",
+        breadcrumbHome: "Home"
+      },
       searchComponents: "Search components",
       exploreSystem: "Explore the system",
       componentsDesc: "Library with ready-made React components.",
@@ -1065,6 +1094,11 @@ export const translations = {
       tokensDesc: "Design tokens, colors, and spacing.",
       universalDesign: "Universal Design",
       universalDesignText: "Built-in accessibility by default. We strictly follow WCAG 2.1 requirements.",
+      palette: {
+        title: "Warm colors",
+        lead: "The color palette has been extended with warm, neutral tones that complement red without competing with it — giving the surface more room to breathe.",
+        link: "See all tokens"
+      },
       readGuidelines: "Read guidelines",
       consistentBrand: "Consistent Brand",
       consistentBrandText: "Design tokens ensure the Red Cross visual profile is maintained across all surfaces.",
@@ -1138,7 +1172,11 @@ export const translations = {
       intro: "The design system contains fundamental components that can be combined in many different ways and in different patterns.",
       searchPlaceholder: "Search for component...",
       searchAriaLabel: "Search components",
-      noResults: "No components found for"
+      noResults: "No components found for",
+      openLabel: "Learn more",
+      ctaTitle: "Explore the components in Storybook",
+      ctaText: "See every variant, state and code example in the interactive documentation.",
+      ctaButton: "Open Storybook"
     },
     // Code Page
     code: {


### PR DESCRIPTION
## Summary

Full visual rework of the documentation SPA (`src/pages`) to match the **Design retning** Figma board and the concept page designs, iterated over several review rounds on localhost.

**Constraints held throughout:** tokens-only styling — every color/radius/space/type value is an existing `--ds-*` token from `rk-design-tokens`; no new CSS custom properties; no hardcoded hex; Source Sans 3 for all type; rk-designsystem components over bespoke markup.

### Per page

- **Home** — typography-led cream hero panel with the *krysset* corner cutout (geometry lifted from the Figma boolean subtract: uniform 20 px radii = `--ds-border-radius-lg`, proportional step) holding the release badge; a specimen shelf of real library components (`inert`, out of tab order); full-bleed pale-blue stat band; «Varme farger» palette strip from the fargepalett slide; nav cards with pink/green/blue media tiles; Figma↔React showcase; green GitHub CTA banner
- **Components** — inset cream hero with pill search; catalog cards per the concept listing anatomy (full-bleed media band, left-aligned maroon title, divider, «Les mer →» with dusty-pink pill hover); green Storybook banner
- **Design & Code** — article pattern (kicker, maroon display title, maroon ingress + thin red rule); matching cream-panel sidebars with pill nav, maroon group titles and dusty-pink thread lines
- **Tokens** — inset hero; palette-circle swatches; alternating cream/white group panels
- **SearchResults** — inset hero + the shared card language
- **App chrome** — dark maroon columns footer (`variant="columns" colorScheme="dark"`) on every page

Dark mode works throughout for free — everything is tokens.

### Notes

- Breaking only in the sense of visual identity; no public npm API changes (pages aren't published to npm)
- New translation keys (NO + EN) for hero, palette strip, and Storybook banner; hero version badge is a static string (same precedent as before)
- Known deferred item: minor remaining differences between the Design/Code sidebars flagged during review — tracked for a follow-up

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 errors
- [x] `npm test` — 306 tests / 51 files pass (incl. the new compliance stories after rebase onto main)
- [x] Visual verification of all six pages + dark mode via Playwright screenshots during development
- [ ] Required CI gate on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)